### PR TITLE
Implemented core functionalities of ODict.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Currently, we consider implmenting the following oblivious RAMs.
 * (Ongoing) [Basic sqaure root ORAM](https://dl.acm.org/doi/pdf/10.1145/28395.28416)
 * (Implemented) [Path ORAM](https://eprint.iacr.org/2013/280.pdf)
 * (Implemented) [Partition-based ORAM](https://www.ndss-symposium.org/wp-content/uploads/2017/09/04_4.pdf)
-* (Ongoing) [Path ORAM-based Oblivious dictionary](https://eprint.iacr.org/2014/185.pdf)
+* (Ongoing) [Path ORAM-based Oblivious dictionary](https://eprint.iacr.org/2014/185.pdf) (Currently the implementation of the position map free version is problemsome.)
 * (TODO) [Cuckoo-hashing-based ORAM](https://arxiv.org/pdf/1007.1259v1.pdf)
 
 In future development, the project may be migrated to an equivalent Rust version with enclave support.

--- a/client/ods_client_main.cc
+++ b/client/ods_client_main.cc
@@ -86,12 +86,18 @@ int main(int argc, char** argv) {
       absl::GetFlag(FLAGS_client_cache_max_size), absl::GetFlag(FLAGS_x),
       absl::GetFlag(FLAGS_block_num), absl::GetFlag(FLAGS_bucket_size));
 
-  // FIXME: This is for test, not for productive environments!
-  for (size_t i = 0; i < 100; i++) {
+  for (size_t i = 0; i < 1000; i++) {
     // Insert some nodes.
 
     auto ret = client->controller_->Insert(std::make_pair(i, std::to_string(i)));
     logger->info("OK");
+  }
+
+  for (size_t i = 0; i < 1000; i++) {
+    // Insert some nodes.
+
+    auto ret = client->controller_->Find(i);
+    logger->info("OK {}", ret->kv_pair_.second);
   }
 
   return 0;

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(oram_controller SHARED
   partition_oram_controller.cc
   linear_oram_controller.cc
   square_root_oram_controller.cc
+  oram.cc
 )
 
 add_library(ods_controller SHARED odict_controller.cc ods_cache.cc)

--- a/core/odict_controller.h
+++ b/core/odict_controller.h
@@ -66,7 +66,7 @@ class OdictController {
   OramStatus InternalRemove(uint32_t key, uint32_t root_id);
 
   // AVL Tree balance functions.
-  TreeNode* Balance(uint32_t root_id);
+  TreeNode* Balance(TreeNode* const root);
   TreeNode* LeftRotate(uint32_t root_id);
   TreeNode* RightRotate(uint32_t root_id);
   TreeNode* LeftRightRotate(uint32_t root_id);

--- a/core/ods_cache.cc
+++ b/core/ods_cache.cc
@@ -34,7 +34,7 @@ uint32_t OdsCache::FindPosById(uint32_t id) {
     }
   }
 
-  return invalid_mask;
+  return 0XFFFFFFFF;
 }
 
 TreeNode* OdsCache::Get(uint32_t id) {

--- a/core/oram.cc
+++ b/core/oram.cc
@@ -14,35 +14,8 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef ORAM_IMPL_BASE_ODS_DEFS_H_
-#define ORAM_IMPL_BASE_ODS_DEFS_H_
+#include "oram.h"
 
-#include <cstdint>
-#include <string>
-
-#ifndef MAX
-#define MAX(lhs, rhs) (lhs >= rhs ? lhs : rhs)
-#endif
-
-#ifndef HEIGHT
-#define HEIGHT(x) \
-  (x == nullptr ? 0 : MAX(x->left_height_, x->right_height_) + 1)
-#endif
-
-namespace oram_impl::ods {
-static const uint32_t invalid_mask = 0ul;
-
-static const std::string pad_val_err =
-    "Pad value is smaller than the read count!";
-
-enum class OdsOperation {
-  kRead = 1,
-  kWrite = 2,
-  kRemove = 3,
-  kInsert = 4,
-  kInvalid = 5,
-};
-
-}  // namespace oram_impl::ods
-
-#endif
+namespace oram_impl {
+std::string GetVersion(void) { return "v1.1.0"; }
+}  // namespace oram_impl

--- a/core/oram.h
+++ b/core/oram.h
@@ -14,35 +14,21 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef ORAM_IMPL_BASE_ODS_DEFS_H_
-#define ORAM_IMPL_BASE_ODS_DEFS_H_
+#ifndef ORAM_IMPL_CORE_ORAM_H_
+#define ORAM_IMPL_CORE_ORAM_H_
 
-#include <cstdint>
 #include <string>
 
-#ifndef MAX
-#define MAX(lhs, rhs) (lhs >= rhs ? lhs : rhs)
-#endif
+#include "linear_oram_controller.h"
+#include "odict_controller.h"
+#include "ods_cache.h"
+#include "oram_controller.h"
+#include "partition_oram_controller.h"
+#include "path_oram_controller.h"
+#include "square_root_oram_controller.h"
 
-#ifndef HEIGHT
-#define HEIGHT(x) \
-  (x == nullptr ? 0 : MAX(x->left_height_, x->right_height_) + 1)
-#endif
+namespace oram_impl {
+std::string GetVersion(void);
+} // namespace oram_impl
 
-namespace oram_impl::ods {
-static const uint32_t invalid_mask = 0ul;
-
-static const std::string pad_val_err =
-    "Pad value is smaller than the read count!";
-
-enum class OdsOperation {
-  kRead = 1,
-  kWrite = 2,
-  kRemove = 3,
-  kInsert = 4,
-  kInvalid = 5,
-};
-
-}  // namespace oram_impl::ods
-
-#endif
+#endif  // ORAM_IMPL_CORE_ORAM_H_

--- a/core/path_oram_controller.h
+++ b/core/path_oram_controller.h
@@ -57,7 +57,7 @@ class PathOramController : public OramController {
                                     oram_block_t* const data,
                                     bool dummy = false);
   // The separate interface for reading is reserved for direct designation of
-  // position, which is useful to ODS.
+  // position, which is useful to, say, ODS.
   virtual OramStatus InternalAccessDirect(Operation op_type, uint32_t address,
                                           uint32_t position,
                                           oram_block_t* const data,


### PR DESCRIPTION
1. Core functionalities of `OdictController` is supported; currently we are using `PathOram` with a position map. This should be eliminated because oblivious data structures maintain an inherent position structure. However, the position map free version contains some bugs and needs to be fixed.
2. Fixed a bug in AVL tree rotation that will cause to read the wrong node.