### PR TITLE
Add more SqrtOram implementations

### DIFF
--- a/base/oram_defs.h
+++ b/base/oram_defs.h
@@ -117,6 +117,8 @@ static const float kPartitionAdjustmentFactor = 1.;
 
 static const uint32_t kMaximumOramStorageNum = 1e5;
 
+static const uint32_t kInvalidMask = 0xFFFFFFFF;
+
 // Alias for SQRT ORam.
 using sqrt_oram_storage_t = std::vector<oram_block_t>;
 

--- a/base/oram_utils.cc
+++ b/base/oram_utils.cc
@@ -363,26 +363,4 @@ oram_impl::OramType StrToType(const std::string& type) {
     return oram_impl::OramType::kInvalid;
   }
 }
-
-std::string PermToStr(const std::vector<uint32_t>& vec) {
-  std::string ans;
-
-  std::for_each(vec.begin(), vec.end(), [&ans](const uint32_t num) {
-    ans += std::to_string(num) + "_";
-  });
-
-  ans.pop_back();
-  return ans;
-}
-
-std::vector<uint32_t> StrToPerm(const std::string& str) {
-  std::vector<std::string> chunks = split(str, '_');
-  std::vector<uint32_t> ans;
-
-  std::for_each(chunks.begin(), chunks.end(), [&](const std::string& str) {
-    ans.emplace_back(std::stoul(str));
-  });
-
-  return ans;
-}
 }  // namespace oram_utils

--- a/base/oram_utils.h
+++ b/base/oram_utils.h
@@ -119,10 +119,6 @@ std::string IntoBinary(uint32_t num);
 uint32_t FromBinary(const std::string& str);
 
 oram_impl::OramType StrToType(const std::string& type);
-
-std::string PermToStr(const std::vector<uint32_t>& vec);
-
-std::vector<uint32_t> StrToPerm(const std::string& str);
 }  // namespace oram_utils
 
 #endif  // ORAM_IMPL_BASE_ORAM_UTILS_H_

--- a/client/oram_client.cc
+++ b/client/oram_client.cc
@@ -73,6 +73,11 @@ OramClient::OramClient(const OramConfig& config) : config_(config) {
       oram_controller_ = std::move(PartitionOramController::GetInstance());
       break;
     }
+    case OramType::kSquareOram: {
+      oram_controller_ = std::move(std::make_unique<SquareRootOramController>(
+          config.id, true, config.block_num));
+      break;
+    }
     default: {
       logger->error("[-] This type is currently fully implemented.");
 

--- a/core/path_oram_controller.cc
+++ b/core/path_oram_controller.cc
@@ -257,14 +257,13 @@ OramStatus PathOramController::ReadBucket(uint32_t path, uint32_t level,
   const size_t bucket_size = response.bucket_size();
   // Then copy the bucket to the vector.
   for (size_t j = 0; j < bucket_size; j++) {
-    oram_block_t* const block = (oram_block_t*)malloc(ORAM_BLOCK_SIZE);
-    oram_utils::ConvertToBlock(response.bucket(j), block);
+    oram_block_t block;
+    oram_utils::ConvertToBlock(response.bucket(j), &block);
 
     // Decrypt the block.
-    oram_utils::DecryptBlock(block, cryptor_.get());
+    oram_utils::DecryptBlock(&block, cryptor_.get());
 
-    bucket->emplace_back(*block);
-    oram_utils::SafeFree(block);
+    bucket->emplace_back(block);
   }
 
   network_communication_ += response.bucket_size();
@@ -351,7 +350,8 @@ OramStatus PathOramController::InternalAccess(Operation op_type,
   if (!is_initialized_) {
     return OramStatus(StatusCode::kInvalidOperation,
                       "Cannot access ORAM before it is initialized."
-                      " You may need to call InitOram() method first.");
+                      " You may need to call `InitOram()` and `FillWithData()` "
+                      "method first.");
   }
 
   logger->debug("ORAM ID: {}, Accessing address {}, op_type {}, dummy {} ", id_,

--- a/core/square_root_oram_controller.h
+++ b/core/square_root_oram_controller.h
@@ -20,6 +20,10 @@
 #include "oram_controller.h"
 
 namespace oram_impl {
+static const uint32_t kShelter = 0ul;
+static const uint32_t kMainMemory = 1ul;
+static const uint32_t kDummy = 2ul;
+
 class SquareRootOramController : public OramController {
   // The layout of the square root ORAM is:
   // ------------------ | ------- | -------|
@@ -51,19 +55,22 @@ class SquareRootOramController : public OramController {
                                     oram_block_t* const data,
                                     bool dummy = false) override;
 
-  // FIXME: Maybe there is no need for separate interfaces.
-  virtual OramStatus ReadBlockFromShelter(oram_block_t* const data);
-  virtual OramStatus ReadBlockFromDummy(void);
-  virtual OramStatus ReadBlockFromMain(uint32_t pos, oram_block_t* const data);
+  virtual OramStatus ReadShelter(oram_block_t* const data);
+  virtual OramStatus ReadBlock(uint32_t from, uint32_t pos,
+                               oram_block_t* const data);
   virtual OramStatus WriteBlock(uint32_t position, oram_block_t* const data,
-                                bool write_to_cache);
+                                bool to);
   virtual OramStatus PermuteOnFull(void);
-  virtual OramStatus DoPermute(const std::string& content);
+  virtual OramStatus DoPermute(const std::vector<uint32_t>& perm);
 
  public:
   // For the convenience of format-preserving encryption, we will round up the
   // block_num to a value such that m + \sqrt{m} =  2^{n}, for some integer n.
   SquareRootOramController(uint32_t id, bool standalone, size_t block_num);
+
+  virtual OramStatus InitOram(void) override;
+  // The user should prepare a permuted initial data vector.
+  virtual OramStatus FillWithData(const std::vector<oram_block_t>& data) override;
 };
 }  // namespace oram_impl
 

--- a/protos/messages.grpc.pb.cc
+++ b/protos/messages.grpc.pb.cc
@@ -25,6 +25,7 @@ static const char* oram_server_method_names[] = {
   "/oram_impl.oram_server/InitTreeOram",
   "/oram_impl.oram_server/InitFlatOram",
   "/oram_impl.oram_server/InitSqrtOram",
+  "/oram_impl.oram_server/LoadSqrtOram",
   "/oram_impl.oram_server/PrintOramTree",
   "/oram_impl.oram_server/ReadPath",
   "/oram_impl.oram_server/WritePath",
@@ -50,19 +51,20 @@ oram_server::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channe
   : channel_(channel), rpcmethod_InitTreeOram_(oram_server_method_names[0], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_InitFlatOram_(oram_server_method_names[1], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_InitSqrtOram_(oram_server_method_names[2], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_PrintOramTree_(oram_server_method_names[3], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_ReadPath_(oram_server_method_names[4], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_WritePath_(oram_server_method_names[5], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_ReadFlatMemory_(oram_server_method_names[6], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_WriteFlatMemory_(oram_server_method_names[7], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_ReadSqrtMemory_(oram_server_method_names[8], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_WriteSqrtMemory_(oram_server_method_names[9], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SqrtPermute_(oram_server_method_names[10], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_CloseConnection_(oram_server_method_names[11], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_KeyExchange_(oram_server_method_names[12], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SendHello_(oram_server_method_names[13], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_ReportServerInformation_(oram_server_method_names[14], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_ResetServer_(oram_server_method_names[15], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_LoadSqrtOram_(oram_server_method_names[3], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_PrintOramTree_(oram_server_method_names[4], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_ReadPath_(oram_server_method_names[5], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_WritePath_(oram_server_method_names[6], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_ReadFlatMemory_(oram_server_method_names[7], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_WriteFlatMemory_(oram_server_method_names[8], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_ReadSqrtMemory_(oram_server_method_names[9], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_WriteSqrtMemory_(oram_server_method_names[10], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SqrtPermute_(oram_server_method_names[11], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_CloseConnection_(oram_server_method_names[12], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_KeyExchange_(oram_server_method_names[13], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SendHello_(oram_server_method_names[14], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_ReportServerInformation_(oram_server_method_names[15], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_ResetServer_(oram_server_method_names[16], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status oram_server::Stub::InitTreeOram(::grpc::ClientContext* context, const ::oram_impl::InitTreeOramRequest& request, ::google::protobuf::Empty* response) {
@@ -130,6 +132,29 @@ void oram_server::Stub::async::InitSqrtOram(::grpc::ClientContext* context, cons
 ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* oram_server::Stub::AsyncInitSqrtOramRaw(::grpc::ClientContext* context, const ::oram_impl::InitSqrtOramRequest& request, ::grpc::CompletionQueue* cq) {
   auto* result =
     this->PrepareAsyncInitSqrtOramRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::Status oram_server::Stub::LoadSqrtOram(::grpc::ClientContext* context, const ::oram_impl::LoadSqrtOramRequest& request, ::google::protobuf::Empty* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::oram_impl::LoadSqrtOramRequest, ::google::protobuf::Empty, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_LoadSqrtOram_, context, request, response);
+}
+
+void oram_server::Stub::async::LoadSqrtOram(::grpc::ClientContext* context, const ::oram_impl::LoadSqrtOramRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::oram_impl::LoadSqrtOramRequest, ::google::protobuf::Empty, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_LoadSqrtOram_, context, request, response, std::move(f));
+}
+
+void oram_server::Stub::async::LoadSqrtOram(::grpc::ClientContext* context, const ::oram_impl::LoadSqrtOramRequest* request, ::google::protobuf::Empty* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_LoadSqrtOram_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* oram_server::Stub::PrepareAsyncLoadSqrtOramRaw(::grpc::ClientContext* context, const ::oram_impl::LoadSqrtOramRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::google::protobuf::Empty, ::oram_impl::LoadSqrtOramRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_LoadSqrtOram_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* oram_server::Stub::AsyncLoadSqrtOramRaw(::grpc::ClientContext* context, const ::oram_impl::LoadSqrtOramRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncLoadSqrtOramRaw(context, request, cq);
   result->StartCall();
   return result;
 }
@@ -467,6 +492,16 @@ oram_server::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       oram_server_method_names[3],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< oram_server::Service, ::oram_impl::LoadSqrtOramRequest, ::google::protobuf::Empty, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](oram_server::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::oram_impl::LoadSqrtOramRequest* req,
+             ::google::protobuf::Empty* resp) {
+               return service->LoadSqrtOram(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      oram_server_method_names[4],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< oram_server::Service, ::oram_impl::PrintOramTreeRequest, ::google::protobuf::Empty, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](oram_server::Service* service,
              ::grpc::ServerContext* ctx,
@@ -475,7 +510,7 @@ oram_server::Service::Service() {
                return service->PrintOramTree(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      oram_server_method_names[4],
+      oram_server_method_names[5],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< oram_server::Service, ::oram_impl::ReadPathRequest, ::oram_impl::ReadPathResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](oram_server::Service* service,
@@ -485,7 +520,7 @@ oram_server::Service::Service() {
                return service->ReadPath(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      oram_server_method_names[5],
+      oram_server_method_names[6],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< oram_server::Service, ::oram_impl::WritePathRequest, ::oram_impl::WritePathResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](oram_server::Service* service,
@@ -495,7 +530,7 @@ oram_server::Service::Service() {
                return service->WritePath(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      oram_server_method_names[6],
+      oram_server_method_names[7],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< oram_server::Service, ::oram_impl::ReadFlatRequest, ::oram_impl::FlatVectorMessage, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](oram_server::Service* service,
@@ -505,7 +540,7 @@ oram_server::Service::Service() {
                return service->ReadFlatMemory(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      oram_server_method_names[7],
+      oram_server_method_names[8],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< oram_server::Service, ::oram_impl::FlatVectorMessage, ::google::protobuf::Empty, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](oram_server::Service* service,
@@ -515,7 +550,7 @@ oram_server::Service::Service() {
                return service->WriteFlatMemory(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      oram_server_method_names[8],
+      oram_server_method_names[9],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< oram_server::Service, ::oram_impl::ReadSqrtRequest, ::oram_impl::SqrtMessage, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](oram_server::Service* service,
@@ -525,7 +560,7 @@ oram_server::Service::Service() {
                return service->ReadSqrtMemory(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      oram_server_method_names[9],
+      oram_server_method_names[10],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< oram_server::Service, ::oram_impl::WriteSqrtMessage, ::google::protobuf::Empty, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](oram_server::Service* service,
@@ -535,7 +570,7 @@ oram_server::Service::Service() {
                return service->WriteSqrtMemory(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      oram_server_method_names[10],
+      oram_server_method_names[11],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< oram_server::Service, ::oram_impl::SqrtPermMessage, ::google::protobuf::Empty, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](oram_server::Service* service,
@@ -545,7 +580,7 @@ oram_server::Service::Service() {
                return service->SqrtPermute(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      oram_server_method_names[11],
+      oram_server_method_names[12],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< oram_server::Service, ::google::protobuf::Empty, ::google::protobuf::Empty, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](oram_server::Service* service,
@@ -555,7 +590,7 @@ oram_server::Service::Service() {
                return service->CloseConnection(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      oram_server_method_names[12],
+      oram_server_method_names[13],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< oram_server::Service, ::oram_impl::KeyExchangeRequest, ::oram_impl::KeyExchangeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](oram_server::Service* service,
@@ -565,7 +600,7 @@ oram_server::Service::Service() {
                return service->KeyExchange(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      oram_server_method_names[13],
+      oram_server_method_names[14],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< oram_server::Service, ::oram_impl::HelloMessage, ::google::protobuf::Empty, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](oram_server::Service* service,
@@ -575,7 +610,7 @@ oram_server::Service::Service() {
                return service->SendHello(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      oram_server_method_names[14],
+      oram_server_method_names[15],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< oram_server::Service, ::google::protobuf::Empty, ::google::protobuf::Empty, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](oram_server::Service* service,
@@ -585,7 +620,7 @@ oram_server::Service::Service() {
                return service->ReportServerInformation(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      oram_server_method_names[15],
+      oram_server_method_names[16],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< oram_server::Service, ::google::protobuf::Empty, ::google::protobuf::Empty, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](oram_server::Service* service,
@@ -614,6 +649,13 @@ oram_server::Service::~Service() {
 }
 
 ::grpc::Status oram_server::Service::InitSqrtOram(::grpc::ServerContext* context, const ::oram_impl::InitSqrtOramRequest* request, ::google::protobuf::Empty* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status oram_server::Service::LoadSqrtOram(::grpc::ServerContext* context, const ::oram_impl::LoadSqrtOramRequest* request, ::google::protobuf::Empty* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/protos/messages.grpc.pb.h
+++ b/protos/messages.grpc.pb.h
@@ -59,6 +59,13 @@ class oram_server final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>> PrepareAsyncInitSqrtOram(::grpc::ClientContext* context, const ::oram_impl::InitSqrtOramRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>>(PrepareAsyncInitSqrtOramRaw(context, request, cq));
     }
+    virtual ::grpc::Status LoadSqrtOram(::grpc::ClientContext* context, const ::oram_impl::LoadSqrtOramRequest& request, ::google::protobuf::Empty* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>> AsyncLoadSqrtOram(::grpc::ClientContext* context, const ::oram_impl::LoadSqrtOramRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>>(AsyncLoadSqrtOramRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>> PrepareAsyncLoadSqrtOram(::grpc::ClientContext* context, const ::oram_impl::LoadSqrtOramRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>>(PrepareAsyncLoadSqrtOramRaw(context, request, cq));
+    }
     virtual ::grpc::Status PrintOramTree(::grpc::ClientContext* context, const ::oram_impl::PrintOramTreeRequest& request, ::google::protobuf::Empty* response) = 0;
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>> AsyncPrintOramTree(::grpc::ClientContext* context, const ::oram_impl::PrintOramTreeRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>>(AsyncPrintOramTreeRaw(context, request, cq));
@@ -164,6 +171,8 @@ class oram_server final {
       virtual void InitFlatOram(::grpc::ClientContext* context, const ::oram_impl::InitFlatOramRequest* request, ::google::protobuf::Empty* response, ::grpc::ClientUnaryReactor* reactor) = 0;
       virtual void InitSqrtOram(::grpc::ClientContext* context, const ::oram_impl::InitSqrtOramRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) = 0;
       virtual void InitSqrtOram(::grpc::ClientContext* context, const ::oram_impl::InitSqrtOramRequest* request, ::google::protobuf::Empty* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      virtual void LoadSqrtOram(::grpc::ClientContext* context, const ::oram_impl::LoadSqrtOramRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void LoadSqrtOram(::grpc::ClientContext* context, const ::oram_impl::LoadSqrtOramRequest* request, ::google::protobuf::Empty* response, ::grpc::ClientUnaryReactor* reactor) = 0;
       virtual void PrintOramTree(::grpc::ClientContext* context, const ::oram_impl::PrintOramTreeRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) = 0;
       virtual void PrintOramTree(::grpc::ClientContext* context, const ::oram_impl::PrintOramTreeRequest* request, ::google::protobuf::Empty* response, ::grpc::ClientUnaryReactor* reactor) = 0;
       virtual void ReadPath(::grpc::ClientContext* context, const ::oram_impl::ReadPathRequest* request, ::oram_impl::ReadPathResponse* response, std::function<void(::grpc::Status)>) = 0;
@@ -205,6 +214,8 @@ class oram_server final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* PrepareAsyncInitFlatOramRaw(::grpc::ClientContext* context, const ::oram_impl::InitFlatOramRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* AsyncInitSqrtOramRaw(::grpc::ClientContext* context, const ::oram_impl::InitSqrtOramRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* PrepareAsyncInitSqrtOramRaw(::grpc::ClientContext* context, const ::oram_impl::InitSqrtOramRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* AsyncLoadSqrtOramRaw(::grpc::ClientContext* context, const ::oram_impl::LoadSqrtOramRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* PrepareAsyncLoadSqrtOramRaw(::grpc::ClientContext* context, const ::oram_impl::LoadSqrtOramRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* AsyncPrintOramTreeRaw(::grpc::ClientContext* context, const ::oram_impl::PrintOramTreeRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* PrepareAsyncPrintOramTreeRaw(::grpc::ClientContext* context, const ::oram_impl::PrintOramTreeRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::oram_impl::ReadPathResponse>* AsyncReadPathRaw(::grpc::ClientContext* context, const ::oram_impl::ReadPathRequest& request, ::grpc::CompletionQueue* cq) = 0;
@@ -255,6 +266,13 @@ class oram_server final {
     }
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>> PrepareAsyncInitSqrtOram(::grpc::ClientContext* context, const ::oram_impl::InitSqrtOramRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>>(PrepareAsyncInitSqrtOramRaw(context, request, cq));
+    }
+    ::grpc::Status LoadSqrtOram(::grpc::ClientContext* context, const ::oram_impl::LoadSqrtOramRequest& request, ::google::protobuf::Empty* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>> AsyncLoadSqrtOram(::grpc::ClientContext* context, const ::oram_impl::LoadSqrtOramRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>>(AsyncLoadSqrtOramRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>> PrepareAsyncLoadSqrtOram(::grpc::ClientContext* context, const ::oram_impl::LoadSqrtOramRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>>(PrepareAsyncLoadSqrtOramRaw(context, request, cq));
     }
     ::grpc::Status PrintOramTree(::grpc::ClientContext* context, const ::oram_impl::PrintOramTreeRequest& request, ::google::protobuf::Empty* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>> AsyncPrintOramTree(::grpc::ClientContext* context, const ::oram_impl::PrintOramTreeRequest& request, ::grpc::CompletionQueue* cq) {
@@ -356,6 +374,8 @@ class oram_server final {
       void InitFlatOram(::grpc::ClientContext* context, const ::oram_impl::InitFlatOramRequest* request, ::google::protobuf::Empty* response, ::grpc::ClientUnaryReactor* reactor) override;
       void InitSqrtOram(::grpc::ClientContext* context, const ::oram_impl::InitSqrtOramRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) override;
       void InitSqrtOram(::grpc::ClientContext* context, const ::oram_impl::InitSqrtOramRequest* request, ::google::protobuf::Empty* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void LoadSqrtOram(::grpc::ClientContext* context, const ::oram_impl::LoadSqrtOramRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) override;
+      void LoadSqrtOram(::grpc::ClientContext* context, const ::oram_impl::LoadSqrtOramRequest* request, ::google::protobuf::Empty* response, ::grpc::ClientUnaryReactor* reactor) override;
       void PrintOramTree(::grpc::ClientContext* context, const ::oram_impl::PrintOramTreeRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) override;
       void PrintOramTree(::grpc::ClientContext* context, const ::oram_impl::PrintOramTreeRequest* request, ::google::protobuf::Empty* response, ::grpc::ClientUnaryReactor* reactor) override;
       void ReadPath(::grpc::ClientContext* context, const ::oram_impl::ReadPathRequest* request, ::oram_impl::ReadPathResponse* response, std::function<void(::grpc::Status)>) override;
@@ -399,6 +419,8 @@ class oram_server final {
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* PrepareAsyncInitFlatOramRaw(::grpc::ClientContext* context, const ::oram_impl::InitFlatOramRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* AsyncInitSqrtOramRaw(::grpc::ClientContext* context, const ::oram_impl::InitSqrtOramRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* PrepareAsyncInitSqrtOramRaw(::grpc::ClientContext* context, const ::oram_impl::InitSqrtOramRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* AsyncLoadSqrtOramRaw(::grpc::ClientContext* context, const ::oram_impl::LoadSqrtOramRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* PrepareAsyncLoadSqrtOramRaw(::grpc::ClientContext* context, const ::oram_impl::LoadSqrtOramRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* AsyncPrintOramTreeRaw(::grpc::ClientContext* context, const ::oram_impl::PrintOramTreeRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* PrepareAsyncPrintOramTreeRaw(::grpc::ClientContext* context, const ::oram_impl::PrintOramTreeRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::oram_impl::ReadPathResponse>* AsyncReadPathRaw(::grpc::ClientContext* context, const ::oram_impl::ReadPathRequest& request, ::grpc::CompletionQueue* cq) override;
@@ -428,6 +450,7 @@ class oram_server final {
     const ::grpc::internal::RpcMethod rpcmethod_InitTreeOram_;
     const ::grpc::internal::RpcMethod rpcmethod_InitFlatOram_;
     const ::grpc::internal::RpcMethod rpcmethod_InitSqrtOram_;
+    const ::grpc::internal::RpcMethod rpcmethod_LoadSqrtOram_;
     const ::grpc::internal::RpcMethod rpcmethod_PrintOramTree_;
     const ::grpc::internal::RpcMethod rpcmethod_ReadPath_;
     const ::grpc::internal::RpcMethod rpcmethod_WritePath_;
@@ -452,6 +475,7 @@ class oram_server final {
     virtual ::grpc::Status InitTreeOram(::grpc::ServerContext* context, const ::oram_impl::InitTreeOramRequest* request, ::google::protobuf::Empty* response);
     virtual ::grpc::Status InitFlatOram(::grpc::ServerContext* context, const ::oram_impl::InitFlatOramRequest* request, ::google::protobuf::Empty* response);
     virtual ::grpc::Status InitSqrtOram(::grpc::ServerContext* context, const ::oram_impl::InitSqrtOramRequest* request, ::google::protobuf::Empty* response);
+    virtual ::grpc::Status LoadSqrtOram(::grpc::ServerContext* context, const ::oram_impl::LoadSqrtOramRequest* request, ::google::protobuf::Empty* response);
     virtual ::grpc::Status PrintOramTree(::grpc::ServerContext* context, const ::oram_impl::PrintOramTreeRequest* request, ::google::protobuf::Empty* response);
     virtual ::grpc::Status ReadPath(::grpc::ServerContext* context, const ::oram_impl::ReadPathRequest* request, ::oram_impl::ReadPathResponse* response);
     virtual ::grpc::Status WritePath(::grpc::ServerContext* context, const ::oram_impl::WritePathRequest* request, ::oram_impl::WritePathResponse* response);
@@ -531,12 +555,32 @@ class oram_server final {
     }
   };
   template <class BaseClass>
+  class WithAsyncMethod_LoadSqrtOram : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_LoadSqrtOram() {
+      ::grpc::Service::MarkMethodAsync(3);
+    }
+    ~WithAsyncMethod_LoadSqrtOram() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status LoadSqrtOram(::grpc::ServerContext* /*context*/, const ::oram_impl::LoadSqrtOramRequest* /*request*/, ::google::protobuf::Empty* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestLoadSqrtOram(::grpc::ServerContext* context, ::oram_impl::LoadSqrtOramRequest* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithAsyncMethod_PrintOramTree : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_PrintOramTree() {
-      ::grpc::Service::MarkMethodAsync(3);
+      ::grpc::Service::MarkMethodAsync(4);
     }
     ~WithAsyncMethod_PrintOramTree() override {
       BaseClassMustBeDerivedFromService(this);
@@ -547,7 +591,7 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestPrintOramTree(::grpc::ServerContext* context, ::oram_impl::PrintOramTreeRequest* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(4, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -556,7 +600,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_ReadPath() {
-      ::grpc::Service::MarkMethodAsync(4);
+      ::grpc::Service::MarkMethodAsync(5);
     }
     ~WithAsyncMethod_ReadPath() override {
       BaseClassMustBeDerivedFromService(this);
@@ -567,7 +611,7 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestReadPath(::grpc::ServerContext* context, ::oram_impl::ReadPathRequest* request, ::grpc::ServerAsyncResponseWriter< ::oram_impl::ReadPathResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(4, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -576,7 +620,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_WritePath() {
-      ::grpc::Service::MarkMethodAsync(5);
+      ::grpc::Service::MarkMethodAsync(6);
     }
     ~WithAsyncMethod_WritePath() override {
       BaseClassMustBeDerivedFromService(this);
@@ -587,7 +631,7 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestWritePath(::grpc::ServerContext* context, ::oram_impl::WritePathRequest* request, ::grpc::ServerAsyncResponseWriter< ::oram_impl::WritePathResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -596,7 +640,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_ReadFlatMemory() {
-      ::grpc::Service::MarkMethodAsync(6);
+      ::grpc::Service::MarkMethodAsync(7);
     }
     ~WithAsyncMethod_ReadFlatMemory() override {
       BaseClassMustBeDerivedFromService(this);
@@ -607,7 +651,7 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestReadFlatMemory(::grpc::ServerContext* context, ::oram_impl::ReadFlatRequest* request, ::grpc::ServerAsyncResponseWriter< ::oram_impl::FlatVectorMessage>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -616,7 +660,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_WriteFlatMemory() {
-      ::grpc::Service::MarkMethodAsync(7);
+      ::grpc::Service::MarkMethodAsync(8);
     }
     ~WithAsyncMethod_WriteFlatMemory() override {
       BaseClassMustBeDerivedFromService(this);
@@ -627,7 +671,7 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestWriteFlatMemory(::grpc::ServerContext* context, ::oram_impl::FlatVectorMessage* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -636,7 +680,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_ReadSqrtMemory() {
-      ::grpc::Service::MarkMethodAsync(8);
+      ::grpc::Service::MarkMethodAsync(9);
     }
     ~WithAsyncMethod_ReadSqrtMemory() override {
       BaseClassMustBeDerivedFromService(this);
@@ -647,7 +691,7 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestReadSqrtMemory(::grpc::ServerContext* context, ::oram_impl::ReadSqrtRequest* request, ::grpc::ServerAsyncResponseWriter< ::oram_impl::SqrtMessage>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -656,7 +700,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_WriteSqrtMemory() {
-      ::grpc::Service::MarkMethodAsync(9);
+      ::grpc::Service::MarkMethodAsync(10);
     }
     ~WithAsyncMethod_WriteSqrtMemory() override {
       BaseClassMustBeDerivedFromService(this);
@@ -667,7 +711,7 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestWriteSqrtMemory(::grpc::ServerContext* context, ::oram_impl::WriteSqrtMessage* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -676,7 +720,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SqrtPermute() {
-      ::grpc::Service::MarkMethodAsync(10);
+      ::grpc::Service::MarkMethodAsync(11);
     }
     ~WithAsyncMethod_SqrtPermute() override {
       BaseClassMustBeDerivedFromService(this);
@@ -687,7 +731,7 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSqrtPermute(::grpc::ServerContext* context, ::oram_impl::SqrtPermMessage* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -696,7 +740,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_CloseConnection() {
-      ::grpc::Service::MarkMethodAsync(11);
+      ::grpc::Service::MarkMethodAsync(12);
     }
     ~WithAsyncMethod_CloseConnection() override {
       BaseClassMustBeDerivedFromService(this);
@@ -707,7 +751,7 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestCloseConnection(::grpc::ServerContext* context, ::google::protobuf::Empty* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -716,7 +760,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_KeyExchange() {
-      ::grpc::Service::MarkMethodAsync(12);
+      ::grpc::Service::MarkMethodAsync(13);
     }
     ~WithAsyncMethod_KeyExchange() override {
       BaseClassMustBeDerivedFromService(this);
@@ -727,7 +771,7 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestKeyExchange(::grpc::ServerContext* context, ::oram_impl::KeyExchangeRequest* request, ::grpc::ServerAsyncResponseWriter< ::oram_impl::KeyExchangeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -736,7 +780,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SendHello() {
-      ::grpc::Service::MarkMethodAsync(13);
+      ::grpc::Service::MarkMethodAsync(14);
     }
     ~WithAsyncMethod_SendHello() override {
       BaseClassMustBeDerivedFromService(this);
@@ -747,7 +791,7 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSendHello(::grpc::ServerContext* context, ::oram_impl::HelloMessage* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -756,7 +800,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_ReportServerInformation() {
-      ::grpc::Service::MarkMethodAsync(14);
+      ::grpc::Service::MarkMethodAsync(15);
     }
     ~WithAsyncMethod_ReportServerInformation() override {
       BaseClassMustBeDerivedFromService(this);
@@ -767,7 +811,7 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestReportServerInformation(::grpc::ServerContext* context, ::google::protobuf::Empty* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -776,7 +820,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_ResetServer() {
-      ::grpc::Service::MarkMethodAsync(15);
+      ::grpc::Service::MarkMethodAsync(16);
     }
     ~WithAsyncMethod_ResetServer() override {
       BaseClassMustBeDerivedFromService(this);
@@ -787,10 +831,10 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestResetServer(::grpc::ServerContext* context, ::google::protobuf::Empty* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_InitTreeOram<WithAsyncMethod_InitFlatOram<WithAsyncMethod_InitSqrtOram<WithAsyncMethod_PrintOramTree<WithAsyncMethod_ReadPath<WithAsyncMethod_WritePath<WithAsyncMethod_ReadFlatMemory<WithAsyncMethod_WriteFlatMemory<WithAsyncMethod_ReadSqrtMemory<WithAsyncMethod_WriteSqrtMemory<WithAsyncMethod_SqrtPermute<WithAsyncMethod_CloseConnection<WithAsyncMethod_KeyExchange<WithAsyncMethod_SendHello<WithAsyncMethod_ReportServerInformation<WithAsyncMethod_ResetServer<Service > > > > > > > > > > > > > > > > AsyncService;
+  typedef WithAsyncMethod_InitTreeOram<WithAsyncMethod_InitFlatOram<WithAsyncMethod_InitSqrtOram<WithAsyncMethod_LoadSqrtOram<WithAsyncMethod_PrintOramTree<WithAsyncMethod_ReadPath<WithAsyncMethod_WritePath<WithAsyncMethod_ReadFlatMemory<WithAsyncMethod_WriteFlatMemory<WithAsyncMethod_ReadSqrtMemory<WithAsyncMethod_WriteSqrtMemory<WithAsyncMethod_SqrtPermute<WithAsyncMethod_CloseConnection<WithAsyncMethod_KeyExchange<WithAsyncMethod_SendHello<WithAsyncMethod_ReportServerInformation<WithAsyncMethod_ResetServer<Service > > > > > > > > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class WithCallbackMethod_InitTreeOram : public BaseClass {
    private:
@@ -873,18 +917,45 @@ class oram_server final {
       ::grpc::CallbackServerContext* /*context*/, const ::oram_impl::InitSqrtOramRequest* /*request*/, ::google::protobuf::Empty* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
+  class WithCallbackMethod_LoadSqrtOram : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_LoadSqrtOram() {
+      ::grpc::Service::MarkMethodCallback(3,
+          new ::grpc::internal::CallbackUnaryHandler< ::oram_impl::LoadSqrtOramRequest, ::google::protobuf::Empty>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::oram_impl::LoadSqrtOramRequest* request, ::google::protobuf::Empty* response) { return this->LoadSqrtOram(context, request, response); }));}
+    void SetMessageAllocatorFor_LoadSqrtOram(
+        ::grpc::MessageAllocator< ::oram_impl::LoadSqrtOramRequest, ::google::protobuf::Empty>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(3);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::oram_impl::LoadSqrtOramRequest, ::google::protobuf::Empty>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_LoadSqrtOram() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status LoadSqrtOram(::grpc::ServerContext* /*context*/, const ::oram_impl::LoadSqrtOramRequest* /*request*/, ::google::protobuf::Empty* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* LoadSqrtOram(
+      ::grpc::CallbackServerContext* /*context*/, const ::oram_impl::LoadSqrtOramRequest* /*request*/, ::google::protobuf::Empty* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
   class WithCallbackMethod_PrintOramTree : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_PrintOramTree() {
-      ::grpc::Service::MarkMethodCallback(3,
+      ::grpc::Service::MarkMethodCallback(4,
           new ::grpc::internal::CallbackUnaryHandler< ::oram_impl::PrintOramTreeRequest, ::google::protobuf::Empty>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::oram_impl::PrintOramTreeRequest* request, ::google::protobuf::Empty* response) { return this->PrintOramTree(context, request, response); }));}
     void SetMessageAllocatorFor_PrintOramTree(
         ::grpc::MessageAllocator< ::oram_impl::PrintOramTreeRequest, ::google::protobuf::Empty>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(3);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(4);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::oram_impl::PrintOramTreeRequest, ::google::protobuf::Empty>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -905,13 +976,13 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_ReadPath() {
-      ::grpc::Service::MarkMethodCallback(4,
+      ::grpc::Service::MarkMethodCallback(5,
           new ::grpc::internal::CallbackUnaryHandler< ::oram_impl::ReadPathRequest, ::oram_impl::ReadPathResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::oram_impl::ReadPathRequest* request, ::oram_impl::ReadPathResponse* response) { return this->ReadPath(context, request, response); }));}
     void SetMessageAllocatorFor_ReadPath(
         ::grpc::MessageAllocator< ::oram_impl::ReadPathRequest, ::oram_impl::ReadPathResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(4);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(5);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::oram_impl::ReadPathRequest, ::oram_impl::ReadPathResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -932,13 +1003,13 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_WritePath() {
-      ::grpc::Service::MarkMethodCallback(5,
+      ::grpc::Service::MarkMethodCallback(6,
           new ::grpc::internal::CallbackUnaryHandler< ::oram_impl::WritePathRequest, ::oram_impl::WritePathResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::oram_impl::WritePathRequest* request, ::oram_impl::WritePathResponse* response) { return this->WritePath(context, request, response); }));}
     void SetMessageAllocatorFor_WritePath(
         ::grpc::MessageAllocator< ::oram_impl::WritePathRequest, ::oram_impl::WritePathResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(5);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(6);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::oram_impl::WritePathRequest, ::oram_impl::WritePathResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -959,13 +1030,13 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_ReadFlatMemory() {
-      ::grpc::Service::MarkMethodCallback(6,
+      ::grpc::Service::MarkMethodCallback(7,
           new ::grpc::internal::CallbackUnaryHandler< ::oram_impl::ReadFlatRequest, ::oram_impl::FlatVectorMessage>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::oram_impl::ReadFlatRequest* request, ::oram_impl::FlatVectorMessage* response) { return this->ReadFlatMemory(context, request, response); }));}
     void SetMessageAllocatorFor_ReadFlatMemory(
         ::grpc::MessageAllocator< ::oram_impl::ReadFlatRequest, ::oram_impl::FlatVectorMessage>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(6);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(7);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::oram_impl::ReadFlatRequest, ::oram_impl::FlatVectorMessage>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -986,13 +1057,13 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_WriteFlatMemory() {
-      ::grpc::Service::MarkMethodCallback(7,
+      ::grpc::Service::MarkMethodCallback(8,
           new ::grpc::internal::CallbackUnaryHandler< ::oram_impl::FlatVectorMessage, ::google::protobuf::Empty>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::oram_impl::FlatVectorMessage* request, ::google::protobuf::Empty* response) { return this->WriteFlatMemory(context, request, response); }));}
     void SetMessageAllocatorFor_WriteFlatMemory(
         ::grpc::MessageAllocator< ::oram_impl::FlatVectorMessage, ::google::protobuf::Empty>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(7);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(8);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::oram_impl::FlatVectorMessage, ::google::protobuf::Empty>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -1013,13 +1084,13 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_ReadSqrtMemory() {
-      ::grpc::Service::MarkMethodCallback(8,
+      ::grpc::Service::MarkMethodCallback(9,
           new ::grpc::internal::CallbackUnaryHandler< ::oram_impl::ReadSqrtRequest, ::oram_impl::SqrtMessage>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::oram_impl::ReadSqrtRequest* request, ::oram_impl::SqrtMessage* response) { return this->ReadSqrtMemory(context, request, response); }));}
     void SetMessageAllocatorFor_ReadSqrtMemory(
         ::grpc::MessageAllocator< ::oram_impl::ReadSqrtRequest, ::oram_impl::SqrtMessage>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(8);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(9);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::oram_impl::ReadSqrtRequest, ::oram_impl::SqrtMessage>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -1040,13 +1111,13 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_WriteSqrtMemory() {
-      ::grpc::Service::MarkMethodCallback(9,
+      ::grpc::Service::MarkMethodCallback(10,
           new ::grpc::internal::CallbackUnaryHandler< ::oram_impl::WriteSqrtMessage, ::google::protobuf::Empty>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::oram_impl::WriteSqrtMessage* request, ::google::protobuf::Empty* response) { return this->WriteSqrtMemory(context, request, response); }));}
     void SetMessageAllocatorFor_WriteSqrtMemory(
         ::grpc::MessageAllocator< ::oram_impl::WriteSqrtMessage, ::google::protobuf::Empty>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(9);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(10);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::oram_impl::WriteSqrtMessage, ::google::protobuf::Empty>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -1067,13 +1138,13 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SqrtPermute() {
-      ::grpc::Service::MarkMethodCallback(10,
+      ::grpc::Service::MarkMethodCallback(11,
           new ::grpc::internal::CallbackUnaryHandler< ::oram_impl::SqrtPermMessage, ::google::protobuf::Empty>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::oram_impl::SqrtPermMessage* request, ::google::protobuf::Empty* response) { return this->SqrtPermute(context, request, response); }));}
     void SetMessageAllocatorFor_SqrtPermute(
         ::grpc::MessageAllocator< ::oram_impl::SqrtPermMessage, ::google::protobuf::Empty>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(10);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(11);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::oram_impl::SqrtPermMessage, ::google::protobuf::Empty>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -1094,13 +1165,13 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_CloseConnection() {
-      ::grpc::Service::MarkMethodCallback(11,
+      ::grpc::Service::MarkMethodCallback(12,
           new ::grpc::internal::CallbackUnaryHandler< ::google::protobuf::Empty, ::google::protobuf::Empty>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::google::protobuf::Empty* request, ::google::protobuf::Empty* response) { return this->CloseConnection(context, request, response); }));}
     void SetMessageAllocatorFor_CloseConnection(
         ::grpc::MessageAllocator< ::google::protobuf::Empty, ::google::protobuf::Empty>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(11);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(12);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::google::protobuf::Empty, ::google::protobuf::Empty>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -1121,13 +1192,13 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_KeyExchange() {
-      ::grpc::Service::MarkMethodCallback(12,
+      ::grpc::Service::MarkMethodCallback(13,
           new ::grpc::internal::CallbackUnaryHandler< ::oram_impl::KeyExchangeRequest, ::oram_impl::KeyExchangeResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::oram_impl::KeyExchangeRequest* request, ::oram_impl::KeyExchangeResponse* response) { return this->KeyExchange(context, request, response); }));}
     void SetMessageAllocatorFor_KeyExchange(
         ::grpc::MessageAllocator< ::oram_impl::KeyExchangeRequest, ::oram_impl::KeyExchangeResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(12);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(13);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::oram_impl::KeyExchangeRequest, ::oram_impl::KeyExchangeResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -1148,13 +1219,13 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SendHello() {
-      ::grpc::Service::MarkMethodCallback(13,
+      ::grpc::Service::MarkMethodCallback(14,
           new ::grpc::internal::CallbackUnaryHandler< ::oram_impl::HelloMessage, ::google::protobuf::Empty>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::oram_impl::HelloMessage* request, ::google::protobuf::Empty* response) { return this->SendHello(context, request, response); }));}
     void SetMessageAllocatorFor_SendHello(
         ::grpc::MessageAllocator< ::oram_impl::HelloMessage, ::google::protobuf::Empty>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(13);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(14);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::oram_impl::HelloMessage, ::google::protobuf::Empty>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -1175,13 +1246,13 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_ReportServerInformation() {
-      ::grpc::Service::MarkMethodCallback(14,
+      ::grpc::Service::MarkMethodCallback(15,
           new ::grpc::internal::CallbackUnaryHandler< ::google::protobuf::Empty, ::google::protobuf::Empty>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::google::protobuf::Empty* request, ::google::protobuf::Empty* response) { return this->ReportServerInformation(context, request, response); }));}
     void SetMessageAllocatorFor_ReportServerInformation(
         ::grpc::MessageAllocator< ::google::protobuf::Empty, ::google::protobuf::Empty>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(14);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(15);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::google::protobuf::Empty, ::google::protobuf::Empty>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -1202,13 +1273,13 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_ResetServer() {
-      ::grpc::Service::MarkMethodCallback(15,
+      ::grpc::Service::MarkMethodCallback(16,
           new ::grpc::internal::CallbackUnaryHandler< ::google::protobuf::Empty, ::google::protobuf::Empty>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::google::protobuf::Empty* request, ::google::protobuf::Empty* response) { return this->ResetServer(context, request, response); }));}
     void SetMessageAllocatorFor_ResetServer(
         ::grpc::MessageAllocator< ::google::protobuf::Empty, ::google::protobuf::Empty>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(15);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(16);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::google::protobuf::Empty, ::google::protobuf::Empty>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -1223,7 +1294,7 @@ class oram_server final {
     virtual ::grpc::ServerUnaryReactor* ResetServer(
       ::grpc::CallbackServerContext* /*context*/, const ::google::protobuf::Empty* /*request*/, ::google::protobuf::Empty* /*response*/)  { return nullptr; }
   };
-  typedef WithCallbackMethod_InitTreeOram<WithCallbackMethod_InitFlatOram<WithCallbackMethod_InitSqrtOram<WithCallbackMethod_PrintOramTree<WithCallbackMethod_ReadPath<WithCallbackMethod_WritePath<WithCallbackMethod_ReadFlatMemory<WithCallbackMethod_WriteFlatMemory<WithCallbackMethod_ReadSqrtMemory<WithCallbackMethod_WriteSqrtMemory<WithCallbackMethod_SqrtPermute<WithCallbackMethod_CloseConnection<WithCallbackMethod_KeyExchange<WithCallbackMethod_SendHello<WithCallbackMethod_ReportServerInformation<WithCallbackMethod_ResetServer<Service > > > > > > > > > > > > > > > > CallbackService;
+  typedef WithCallbackMethod_InitTreeOram<WithCallbackMethod_InitFlatOram<WithCallbackMethod_InitSqrtOram<WithCallbackMethod_LoadSqrtOram<WithCallbackMethod_PrintOramTree<WithCallbackMethod_ReadPath<WithCallbackMethod_WritePath<WithCallbackMethod_ReadFlatMemory<WithCallbackMethod_WriteFlatMemory<WithCallbackMethod_ReadSqrtMemory<WithCallbackMethod_WriteSqrtMemory<WithCallbackMethod_SqrtPermute<WithCallbackMethod_CloseConnection<WithCallbackMethod_KeyExchange<WithCallbackMethod_SendHello<WithCallbackMethod_ReportServerInformation<WithCallbackMethod_ResetServer<Service > > > > > > > > > > > > > > > > > CallbackService;
   typedef CallbackService ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_InitTreeOram : public BaseClass {
@@ -1277,12 +1348,29 @@ class oram_server final {
     }
   };
   template <class BaseClass>
+  class WithGenericMethod_LoadSqrtOram : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_LoadSqrtOram() {
+      ::grpc::Service::MarkMethodGeneric(3);
+    }
+    ~WithGenericMethod_LoadSqrtOram() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status LoadSqrtOram(::grpc::ServerContext* /*context*/, const ::oram_impl::LoadSqrtOramRequest* /*request*/, ::google::protobuf::Empty* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
   class WithGenericMethod_PrintOramTree : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_PrintOramTree() {
-      ::grpc::Service::MarkMethodGeneric(3);
+      ::grpc::Service::MarkMethodGeneric(4);
     }
     ~WithGenericMethod_PrintOramTree() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1299,7 +1387,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_ReadPath() {
-      ::grpc::Service::MarkMethodGeneric(4);
+      ::grpc::Service::MarkMethodGeneric(5);
     }
     ~WithGenericMethod_ReadPath() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1316,7 +1404,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_WritePath() {
-      ::grpc::Service::MarkMethodGeneric(5);
+      ::grpc::Service::MarkMethodGeneric(6);
     }
     ~WithGenericMethod_WritePath() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1333,7 +1421,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_ReadFlatMemory() {
-      ::grpc::Service::MarkMethodGeneric(6);
+      ::grpc::Service::MarkMethodGeneric(7);
     }
     ~WithGenericMethod_ReadFlatMemory() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1350,7 +1438,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_WriteFlatMemory() {
-      ::grpc::Service::MarkMethodGeneric(7);
+      ::grpc::Service::MarkMethodGeneric(8);
     }
     ~WithGenericMethod_WriteFlatMemory() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1367,7 +1455,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_ReadSqrtMemory() {
-      ::grpc::Service::MarkMethodGeneric(8);
+      ::grpc::Service::MarkMethodGeneric(9);
     }
     ~WithGenericMethod_ReadSqrtMemory() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1384,7 +1472,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_WriteSqrtMemory() {
-      ::grpc::Service::MarkMethodGeneric(9);
+      ::grpc::Service::MarkMethodGeneric(10);
     }
     ~WithGenericMethod_WriteSqrtMemory() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1401,7 +1489,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SqrtPermute() {
-      ::grpc::Service::MarkMethodGeneric(10);
+      ::grpc::Service::MarkMethodGeneric(11);
     }
     ~WithGenericMethod_SqrtPermute() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1418,7 +1506,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_CloseConnection() {
-      ::grpc::Service::MarkMethodGeneric(11);
+      ::grpc::Service::MarkMethodGeneric(12);
     }
     ~WithGenericMethod_CloseConnection() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1435,7 +1523,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_KeyExchange() {
-      ::grpc::Service::MarkMethodGeneric(12);
+      ::grpc::Service::MarkMethodGeneric(13);
     }
     ~WithGenericMethod_KeyExchange() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1452,7 +1540,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SendHello() {
-      ::grpc::Service::MarkMethodGeneric(13);
+      ::grpc::Service::MarkMethodGeneric(14);
     }
     ~WithGenericMethod_SendHello() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1469,7 +1557,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_ReportServerInformation() {
-      ::grpc::Service::MarkMethodGeneric(14);
+      ::grpc::Service::MarkMethodGeneric(15);
     }
     ~WithGenericMethod_ReportServerInformation() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1486,7 +1574,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_ResetServer() {
-      ::grpc::Service::MarkMethodGeneric(15);
+      ::grpc::Service::MarkMethodGeneric(16);
     }
     ~WithGenericMethod_ResetServer() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1558,12 +1646,32 @@ class oram_server final {
     }
   };
   template <class BaseClass>
+  class WithRawMethod_LoadSqrtOram : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_LoadSqrtOram() {
+      ::grpc::Service::MarkMethodRaw(3);
+    }
+    ~WithRawMethod_LoadSqrtOram() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status LoadSqrtOram(::grpc::ServerContext* /*context*/, const ::oram_impl::LoadSqrtOramRequest* /*request*/, ::google::protobuf::Empty* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestLoadSqrtOram(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithRawMethod_PrintOramTree : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_PrintOramTree() {
-      ::grpc::Service::MarkMethodRaw(3);
+      ::grpc::Service::MarkMethodRaw(4);
     }
     ~WithRawMethod_PrintOramTree() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1574,7 +1682,7 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestPrintOramTree(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(4, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1583,7 +1691,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_ReadPath() {
-      ::grpc::Service::MarkMethodRaw(4);
+      ::grpc::Service::MarkMethodRaw(5);
     }
     ~WithRawMethod_ReadPath() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1594,7 +1702,7 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestReadPath(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(4, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1603,7 +1711,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_WritePath() {
-      ::grpc::Service::MarkMethodRaw(5);
+      ::grpc::Service::MarkMethodRaw(6);
     }
     ~WithRawMethod_WritePath() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1614,7 +1722,7 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestWritePath(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1623,7 +1731,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_ReadFlatMemory() {
-      ::grpc::Service::MarkMethodRaw(6);
+      ::grpc::Service::MarkMethodRaw(7);
     }
     ~WithRawMethod_ReadFlatMemory() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1634,7 +1742,7 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestReadFlatMemory(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1643,7 +1751,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_WriteFlatMemory() {
-      ::grpc::Service::MarkMethodRaw(7);
+      ::grpc::Service::MarkMethodRaw(8);
     }
     ~WithRawMethod_WriteFlatMemory() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1654,7 +1762,7 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestWriteFlatMemory(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1663,7 +1771,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_ReadSqrtMemory() {
-      ::grpc::Service::MarkMethodRaw(8);
+      ::grpc::Service::MarkMethodRaw(9);
     }
     ~WithRawMethod_ReadSqrtMemory() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1674,7 +1782,7 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestReadSqrtMemory(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1683,7 +1791,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_WriteSqrtMemory() {
-      ::grpc::Service::MarkMethodRaw(9);
+      ::grpc::Service::MarkMethodRaw(10);
     }
     ~WithRawMethod_WriteSqrtMemory() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1694,7 +1802,7 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestWriteSqrtMemory(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1703,7 +1811,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SqrtPermute() {
-      ::grpc::Service::MarkMethodRaw(10);
+      ::grpc::Service::MarkMethodRaw(11);
     }
     ~WithRawMethod_SqrtPermute() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1714,7 +1822,7 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSqrtPermute(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1723,7 +1831,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_CloseConnection() {
-      ::grpc::Service::MarkMethodRaw(11);
+      ::grpc::Service::MarkMethodRaw(12);
     }
     ~WithRawMethod_CloseConnection() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1734,7 +1842,7 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestCloseConnection(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1743,7 +1851,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_KeyExchange() {
-      ::grpc::Service::MarkMethodRaw(12);
+      ::grpc::Service::MarkMethodRaw(13);
     }
     ~WithRawMethod_KeyExchange() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1754,7 +1862,7 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestKeyExchange(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1763,7 +1871,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SendHello() {
-      ::grpc::Service::MarkMethodRaw(13);
+      ::grpc::Service::MarkMethodRaw(14);
     }
     ~WithRawMethod_SendHello() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1774,7 +1882,7 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSendHello(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1783,7 +1891,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_ReportServerInformation() {
-      ::grpc::Service::MarkMethodRaw(14);
+      ::grpc::Service::MarkMethodRaw(15);
     }
     ~WithRawMethod_ReportServerInformation() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1794,7 +1902,7 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestReportServerInformation(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1803,7 +1911,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_ResetServer() {
-      ::grpc::Service::MarkMethodRaw(15);
+      ::grpc::Service::MarkMethodRaw(16);
     }
     ~WithRawMethod_ResetServer() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1814,7 +1922,7 @@ class oram_server final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestResetServer(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1884,12 +1992,34 @@ class oram_server final {
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
+  class WithRawCallbackMethod_LoadSqrtOram : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_LoadSqrtOram() {
+      ::grpc::Service::MarkMethodRawCallback(3,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->LoadSqrtOram(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_LoadSqrtOram() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status LoadSqrtOram(::grpc::ServerContext* /*context*/, const ::oram_impl::LoadSqrtOramRequest* /*request*/, ::google::protobuf::Empty* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* LoadSqrtOram(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
   class WithRawCallbackMethod_PrintOramTree : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_PrintOramTree() {
-      ::grpc::Service::MarkMethodRawCallback(3,
+      ::grpc::Service::MarkMethodRawCallback(4,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->PrintOramTree(context, request, response); }));
@@ -1911,7 +2041,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_ReadPath() {
-      ::grpc::Service::MarkMethodRawCallback(4,
+      ::grpc::Service::MarkMethodRawCallback(5,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->ReadPath(context, request, response); }));
@@ -1933,7 +2063,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_WritePath() {
-      ::grpc::Service::MarkMethodRawCallback(5,
+      ::grpc::Service::MarkMethodRawCallback(6,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->WritePath(context, request, response); }));
@@ -1955,7 +2085,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_ReadFlatMemory() {
-      ::grpc::Service::MarkMethodRawCallback(6,
+      ::grpc::Service::MarkMethodRawCallback(7,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->ReadFlatMemory(context, request, response); }));
@@ -1977,7 +2107,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_WriteFlatMemory() {
-      ::grpc::Service::MarkMethodRawCallback(7,
+      ::grpc::Service::MarkMethodRawCallback(8,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->WriteFlatMemory(context, request, response); }));
@@ -1999,7 +2129,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_ReadSqrtMemory() {
-      ::grpc::Service::MarkMethodRawCallback(8,
+      ::grpc::Service::MarkMethodRawCallback(9,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->ReadSqrtMemory(context, request, response); }));
@@ -2021,7 +2151,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_WriteSqrtMemory() {
-      ::grpc::Service::MarkMethodRawCallback(9,
+      ::grpc::Service::MarkMethodRawCallback(10,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->WriteSqrtMemory(context, request, response); }));
@@ -2043,7 +2173,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SqrtPermute() {
-      ::grpc::Service::MarkMethodRawCallback(10,
+      ::grpc::Service::MarkMethodRawCallback(11,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SqrtPermute(context, request, response); }));
@@ -2065,7 +2195,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_CloseConnection() {
-      ::grpc::Service::MarkMethodRawCallback(11,
+      ::grpc::Service::MarkMethodRawCallback(12,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->CloseConnection(context, request, response); }));
@@ -2087,7 +2217,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_KeyExchange() {
-      ::grpc::Service::MarkMethodRawCallback(12,
+      ::grpc::Service::MarkMethodRawCallback(13,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->KeyExchange(context, request, response); }));
@@ -2109,7 +2239,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SendHello() {
-      ::grpc::Service::MarkMethodRawCallback(13,
+      ::grpc::Service::MarkMethodRawCallback(14,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SendHello(context, request, response); }));
@@ -2131,7 +2261,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_ReportServerInformation() {
-      ::grpc::Service::MarkMethodRawCallback(14,
+      ::grpc::Service::MarkMethodRawCallback(15,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->ReportServerInformation(context, request, response); }));
@@ -2153,7 +2283,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_ResetServer() {
-      ::grpc::Service::MarkMethodRawCallback(15,
+      ::grpc::Service::MarkMethodRawCallback(16,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->ResetServer(context, request, response); }));
@@ -2251,12 +2381,39 @@ class oram_server final {
     virtual ::grpc::Status StreamedInitSqrtOram(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::oram_impl::InitSqrtOramRequest,::google::protobuf::Empty>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
+  class WithStreamedUnaryMethod_LoadSqrtOram : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_LoadSqrtOram() {
+      ::grpc::Service::MarkMethodStreamed(3,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::oram_impl::LoadSqrtOramRequest, ::google::protobuf::Empty>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::oram_impl::LoadSqrtOramRequest, ::google::protobuf::Empty>* streamer) {
+                       return this->StreamedLoadSqrtOram(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_LoadSqrtOram() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status LoadSqrtOram(::grpc::ServerContext* /*context*/, const ::oram_impl::LoadSqrtOramRequest* /*request*/, ::google::protobuf::Empty* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedLoadSqrtOram(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::oram_impl::LoadSqrtOramRequest,::google::protobuf::Empty>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_PrintOramTree : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_PrintOramTree() {
-      ::grpc::Service::MarkMethodStreamed(3,
+      ::grpc::Service::MarkMethodStreamed(4,
         new ::grpc::internal::StreamedUnaryHandler<
           ::oram_impl::PrintOramTreeRequest, ::google::protobuf::Empty>(
             [this](::grpc::ServerContext* context,
@@ -2283,7 +2440,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_ReadPath() {
-      ::grpc::Service::MarkMethodStreamed(4,
+      ::grpc::Service::MarkMethodStreamed(5,
         new ::grpc::internal::StreamedUnaryHandler<
           ::oram_impl::ReadPathRequest, ::oram_impl::ReadPathResponse>(
             [this](::grpc::ServerContext* context,
@@ -2310,7 +2467,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_WritePath() {
-      ::grpc::Service::MarkMethodStreamed(5,
+      ::grpc::Service::MarkMethodStreamed(6,
         new ::grpc::internal::StreamedUnaryHandler<
           ::oram_impl::WritePathRequest, ::oram_impl::WritePathResponse>(
             [this](::grpc::ServerContext* context,
@@ -2337,7 +2494,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_ReadFlatMemory() {
-      ::grpc::Service::MarkMethodStreamed(6,
+      ::grpc::Service::MarkMethodStreamed(7,
         new ::grpc::internal::StreamedUnaryHandler<
           ::oram_impl::ReadFlatRequest, ::oram_impl::FlatVectorMessage>(
             [this](::grpc::ServerContext* context,
@@ -2364,7 +2521,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_WriteFlatMemory() {
-      ::grpc::Service::MarkMethodStreamed(7,
+      ::grpc::Service::MarkMethodStreamed(8,
         new ::grpc::internal::StreamedUnaryHandler<
           ::oram_impl::FlatVectorMessage, ::google::protobuf::Empty>(
             [this](::grpc::ServerContext* context,
@@ -2391,7 +2548,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_ReadSqrtMemory() {
-      ::grpc::Service::MarkMethodStreamed(8,
+      ::grpc::Service::MarkMethodStreamed(9,
         new ::grpc::internal::StreamedUnaryHandler<
           ::oram_impl::ReadSqrtRequest, ::oram_impl::SqrtMessage>(
             [this](::grpc::ServerContext* context,
@@ -2418,7 +2575,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_WriteSqrtMemory() {
-      ::grpc::Service::MarkMethodStreamed(9,
+      ::grpc::Service::MarkMethodStreamed(10,
         new ::grpc::internal::StreamedUnaryHandler<
           ::oram_impl::WriteSqrtMessage, ::google::protobuf::Empty>(
             [this](::grpc::ServerContext* context,
@@ -2445,7 +2602,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SqrtPermute() {
-      ::grpc::Service::MarkMethodStreamed(10,
+      ::grpc::Service::MarkMethodStreamed(11,
         new ::grpc::internal::StreamedUnaryHandler<
           ::oram_impl::SqrtPermMessage, ::google::protobuf::Empty>(
             [this](::grpc::ServerContext* context,
@@ -2472,7 +2629,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_CloseConnection() {
-      ::grpc::Service::MarkMethodStreamed(11,
+      ::grpc::Service::MarkMethodStreamed(12,
         new ::grpc::internal::StreamedUnaryHandler<
           ::google::protobuf::Empty, ::google::protobuf::Empty>(
             [this](::grpc::ServerContext* context,
@@ -2499,7 +2656,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_KeyExchange() {
-      ::grpc::Service::MarkMethodStreamed(12,
+      ::grpc::Service::MarkMethodStreamed(13,
         new ::grpc::internal::StreamedUnaryHandler<
           ::oram_impl::KeyExchangeRequest, ::oram_impl::KeyExchangeResponse>(
             [this](::grpc::ServerContext* context,
@@ -2526,7 +2683,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SendHello() {
-      ::grpc::Service::MarkMethodStreamed(13,
+      ::grpc::Service::MarkMethodStreamed(14,
         new ::grpc::internal::StreamedUnaryHandler<
           ::oram_impl::HelloMessage, ::google::protobuf::Empty>(
             [this](::grpc::ServerContext* context,
@@ -2553,7 +2710,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_ReportServerInformation() {
-      ::grpc::Service::MarkMethodStreamed(14,
+      ::grpc::Service::MarkMethodStreamed(15,
         new ::grpc::internal::StreamedUnaryHandler<
           ::google::protobuf::Empty, ::google::protobuf::Empty>(
             [this](::grpc::ServerContext* context,
@@ -2580,7 +2737,7 @@ class oram_server final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_ResetServer() {
-      ::grpc::Service::MarkMethodStreamed(15,
+      ::grpc::Service::MarkMethodStreamed(16,
         new ::grpc::internal::StreamedUnaryHandler<
           ::google::protobuf::Empty, ::google::protobuf::Empty>(
             [this](::grpc::ServerContext* context,
@@ -2601,9 +2758,9 @@ class oram_server final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedResetServer(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::google::protobuf::Empty,::google::protobuf::Empty>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_InitTreeOram<WithStreamedUnaryMethod_InitFlatOram<WithStreamedUnaryMethod_InitSqrtOram<WithStreamedUnaryMethod_PrintOramTree<WithStreamedUnaryMethod_ReadPath<WithStreamedUnaryMethod_WritePath<WithStreamedUnaryMethod_ReadFlatMemory<WithStreamedUnaryMethod_WriteFlatMemory<WithStreamedUnaryMethod_ReadSqrtMemory<WithStreamedUnaryMethod_WriteSqrtMemory<WithStreamedUnaryMethod_SqrtPermute<WithStreamedUnaryMethod_CloseConnection<WithStreamedUnaryMethod_KeyExchange<WithStreamedUnaryMethod_SendHello<WithStreamedUnaryMethod_ReportServerInformation<WithStreamedUnaryMethod_ResetServer<Service > > > > > > > > > > > > > > > > StreamedUnaryService;
+  typedef WithStreamedUnaryMethod_InitTreeOram<WithStreamedUnaryMethod_InitFlatOram<WithStreamedUnaryMethod_InitSqrtOram<WithStreamedUnaryMethod_LoadSqrtOram<WithStreamedUnaryMethod_PrintOramTree<WithStreamedUnaryMethod_ReadPath<WithStreamedUnaryMethod_WritePath<WithStreamedUnaryMethod_ReadFlatMemory<WithStreamedUnaryMethod_WriteFlatMemory<WithStreamedUnaryMethod_ReadSqrtMemory<WithStreamedUnaryMethod_WriteSqrtMemory<WithStreamedUnaryMethod_SqrtPermute<WithStreamedUnaryMethod_CloseConnection<WithStreamedUnaryMethod_KeyExchange<WithStreamedUnaryMethod_SendHello<WithStreamedUnaryMethod_ReportServerInformation<WithStreamedUnaryMethod_ResetServer<Service > > > > > > > > > > > > > > > > > StreamedUnaryService;
   typedef Service SplitStreamedService;
-  typedef WithStreamedUnaryMethod_InitTreeOram<WithStreamedUnaryMethod_InitFlatOram<WithStreamedUnaryMethod_InitSqrtOram<WithStreamedUnaryMethod_PrintOramTree<WithStreamedUnaryMethod_ReadPath<WithStreamedUnaryMethod_WritePath<WithStreamedUnaryMethod_ReadFlatMemory<WithStreamedUnaryMethod_WriteFlatMemory<WithStreamedUnaryMethod_ReadSqrtMemory<WithStreamedUnaryMethod_WriteSqrtMemory<WithStreamedUnaryMethod_SqrtPermute<WithStreamedUnaryMethod_CloseConnection<WithStreamedUnaryMethod_KeyExchange<WithStreamedUnaryMethod_SendHello<WithStreamedUnaryMethod_ReportServerInformation<WithStreamedUnaryMethod_ResetServer<Service > > > > > > > > > > > > > > > > StreamedService;
+  typedef WithStreamedUnaryMethod_InitTreeOram<WithStreamedUnaryMethod_InitFlatOram<WithStreamedUnaryMethod_InitSqrtOram<WithStreamedUnaryMethod_LoadSqrtOram<WithStreamedUnaryMethod_PrintOramTree<WithStreamedUnaryMethod_ReadPath<WithStreamedUnaryMethod_WritePath<WithStreamedUnaryMethod_ReadFlatMemory<WithStreamedUnaryMethod_WriteFlatMemory<WithStreamedUnaryMethod_ReadSqrtMemory<WithStreamedUnaryMethod_WriteSqrtMemory<WithStreamedUnaryMethod_SqrtPermute<WithStreamedUnaryMethod_CloseConnection<WithStreamedUnaryMethod_KeyExchange<WithStreamedUnaryMethod_SendHello<WithStreamedUnaryMethod_ReportServerInformation<WithStreamedUnaryMethod_ResetServer<Service > > > > > > > > > > > > > > > > > StreamedService;
 };
 
 }  // namespace oram_impl

--- a/protos/messages.pb.cc
+++ b/protos/messages.pb.cc
@@ -120,6 +120,20 @@ struct InitSqrtOramRequestDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 InitSqrtOramRequestDefaultTypeInternal _InitSqrtOramRequest_default_instance_;
+PROTOBUF_CONSTEXPR LoadSqrtOramRequest::LoadSqrtOramRequest(
+    ::_pbi::ConstantInitialized): _impl_{
+    /*decltype(_impl_.contents_)*/{}
+  , /*decltype(_impl_.header_)*/nullptr
+  , /*decltype(_impl_._cached_size_)*/{}} {}
+struct LoadSqrtOramRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR LoadSqrtOramRequestDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~LoadSqrtOramRequestDefaultTypeInternal() {}
+  union {
+    LoadSqrtOramRequest _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 LoadSqrtOramRequestDefaultTypeInternal _LoadSqrtOramRequest_default_instance_;
 PROTOBUF_CONSTEXPR FlatVectorMessage::FlatVectorMessage(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_.content_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
@@ -166,7 +180,8 @@ struct WriteSqrtMessageDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 WriteSqrtMessageDefaultTypeInternal _WriteSqrtMessage_default_instance_;
 PROTOBUF_CONSTEXPR SqrtPermMessage::SqrtPermMessage(
     ::_pbi::ConstantInitialized): _impl_{
-    /*decltype(_impl_.content_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+    /*decltype(_impl_.perms_)*/{}
+  , /*decltype(_impl_._perms_cached_byte_size_)*/{0}
   , /*decltype(_impl_.header_)*/nullptr
   , /*decltype(_impl_._cached_size_)*/{}} {}
 struct SqrtPermMessageDefaultTypeInternal {
@@ -281,7 +296,7 @@ struct WritePathResponseDefaultTypeInternal {
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 WritePathResponseDefaultTypeInternal _WritePathResponse_default_instance_;
 }  // namespace oram_impl
-static ::_pb::Metadata file_level_metadata_messages_2eproto[18];
+static ::_pb::Metadata file_level_metadata_messages_2eproto[19];
 static const ::_pb::EnumDescriptor* file_level_enum_descriptors_messages_2eproto[1];
 static constexpr ::_pb::ServiceDescriptor const** file_level_service_descriptors_messages_2eproto = nullptr;
 
@@ -344,6 +359,14 @@ const uint32_t TableStruct_messages_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE
   PROTOBUF_FIELD_OFFSET(::oram_impl::InitSqrtOramRequest, _impl_.squared_m_),
   PROTOBUF_FIELD_OFFSET(::oram_impl::InitSqrtOramRequest, _impl_.block_size_),
   ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::oram_impl::LoadSqrtOramRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::oram_impl::LoadSqrtOramRequest, _impl_.header_),
+  PROTOBUF_FIELD_OFFSET(::oram_impl::LoadSqrtOramRequest, _impl_.contents_),
+  ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::oram_impl::FlatVectorMessage, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
@@ -376,7 +399,7 @@ const uint32_t TableStruct_messages_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE
   ~0u,  // no _weak_field_map_
   ~0u,  // no _inlined_string_donated_
   PROTOBUF_FIELD_OFFSET(::oram_impl::SqrtPermMessage, _impl_.header_),
-  PROTOBUF_FIELD_OFFSET(::oram_impl::SqrtPermMessage, _impl_.content_),
+  PROTOBUF_FIELD_OFFSET(::oram_impl::SqrtPermMessage, _impl_.perms_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::oram_impl::InitTreeOramRequest, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -452,17 +475,18 @@ static const ::_pbi::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protode
   { 31, -1, -1, sizeof(::oram_impl::KeyExchangeResponse)},
   { 38, -1, -1, sizeof(::oram_impl::InitFlatOramRequest)},
   { 47, -1, -1, sizeof(::oram_impl::InitSqrtOramRequest)},
-  { 57, -1, -1, sizeof(::oram_impl::FlatVectorMessage)},
-  { 65, -1, -1, sizeof(::oram_impl::SqrtMessage)},
-  { 73, -1, -1, sizeof(::oram_impl::WriteSqrtMessage)},
-  { 83, -1, -1, sizeof(::oram_impl::SqrtPermMessage)},
-  { 91, -1, -1, sizeof(::oram_impl::InitTreeOramRequest)},
-  { 101, -1, -1, sizeof(::oram_impl::ReadFlatRequest)},
-  { 108, -1, -1, sizeof(::oram_impl::ReadSqrtRequest)},
-  { 117, -1, -1, sizeof(::oram_impl::ReadPathRequest)},
-  { 126, -1, -1, sizeof(::oram_impl::ReadPathResponse)},
-  { 133, 145, -1, sizeof(::oram_impl::WritePathRequest)},
-  { 151, -1, -1, sizeof(::oram_impl::WritePathResponse)},
+  { 57, -1, -1, sizeof(::oram_impl::LoadSqrtOramRequest)},
+  { 65, -1, -1, sizeof(::oram_impl::FlatVectorMessage)},
+  { 73, -1, -1, sizeof(::oram_impl::SqrtMessage)},
+  { 81, -1, -1, sizeof(::oram_impl::WriteSqrtMessage)},
+  { 91, -1, -1, sizeof(::oram_impl::SqrtPermMessage)},
+  { 99, -1, -1, sizeof(::oram_impl::InitTreeOramRequest)},
+  { 109, -1, -1, sizeof(::oram_impl::ReadFlatRequest)},
+  { 116, -1, -1, sizeof(::oram_impl::ReadSqrtRequest)},
+  { 125, -1, -1, sizeof(::oram_impl::ReadPathRequest)},
+  { 134, -1, -1, sizeof(::oram_impl::ReadPathResponse)},
+  { 141, 153, -1, sizeof(::oram_impl::WritePathRequest)},
+  { 159, -1, -1, sizeof(::oram_impl::WritePathResponse)},
 };
 
 static const ::_pb::Message* const file_default_instances[] = {
@@ -473,6 +497,7 @@ static const ::_pb::Message* const file_default_instances[] = {
   &::oram_impl::_KeyExchangeResponse_default_instance_._instance,
   &::oram_impl::_InitFlatOramRequest_default_instance_._instance,
   &::oram_impl::_InitSqrtOramRequest_default_instance_._instance,
+  &::oram_impl::_LoadSqrtOramRequest_default_instance_._instance,
   &::oram_impl::_FlatVectorMessage_default_instance_._instance,
   &::oram_impl::_SqrtMessage_default_instance_._instance,
   &::oram_impl::_WriteSqrtMessage_default_instance_._instance,
@@ -500,71 +525,75 @@ const char descriptor_table_protodef_messages_2eproto[] PROTOBUF_SECTION_VARIABL
   "ze\030\003 \001(\r\"x\n\023InitSqrtOramRequest\022(\n\006heade"
   "r\030\001 \001(\0132\030.oram_impl.RequestHeader\022\020\n\010cap"
   "acity\030\002 \001(\r\022\021\n\tsquared_m\030\003 \001(\r\022\022\n\nblock_"
-  "size\030\004 \001(\r\"N\n\021FlatVectorMessage\022(\n\006heade"
-  "r\030\001 \001(\0132\030.oram_impl.RequestHeader\022\017\n\007con"
-  "tent\030\002 \001(\014\"H\n\013SqrtMessage\022(\n\006header\030\001 \001("
-  "\0132\030.oram_impl.RequestHeader\022\017\n\007content\030\002"
-  " \001(\014\"r\n\020WriteSqrtMessage\022(\n\006header\030\001 \001(\013"
-  "2\030.oram_impl.RequestHeader\022\017\n\007content\030\002 "
-  "\001(\014\022\026\n\016write_to_cache\030\003 \001(\010\022\013\n\003pos\030\004 \001(\r"
-  "\"L\n\017SqrtPermMessage\022(\n\006header\030\001 \001(\0132\030.or"
-  "am_impl.RequestHeader\022\017\n\007content\030\002 \001(\014\"|"
-  "\n\023InitTreeOramRequest\022(\n\006header\030\001 \001(\0132\030."
-  "oram_impl.RequestHeader\022\023\n\013bucket_size\030\002"
-  " \001(\r\022\022\n\nbucket_num\030\003 \001(\r\022\022\n\nblock_size\030\004"
-  " \001(\r\";\n\017ReadFlatRequest\022(\n\006header\030\001 \001(\0132"
-  "\030.oram_impl.RequestHeader\"[\n\017ReadSqrtReq"
-  "uest\022(\n\006header\030\001 \001(\0132\030.oram_impl.Request"
-  "Header\022\013\n\003tag\030\002 \001(\r\022\021\n\tread_from\030\003 \001(\r\"X"
-  "\n\017ReadPathRequest\022(\n\006header\030\001 \001(\0132\030.oram"
-  "_impl.RequestHeader\022\014\n\004path\030\002 \001(\r\022\r\n\005lev"
-  "el\030\003 \001(\r\"\"\n\020ReadPathResponse\022\016\n\006bucket\030\001"
-  " \003(\014\"\266\001\n\020WritePathRequest\022(\n\006header\030\001 \001("
-  "\0132\030.oram_impl.RequestHeader\022\014\n\004path\030\002 \001("
-  "\r\022\r\n\005level\030\003 \001(\r\022\016\n\006bucket\030\004 \003(\014\022\"\n\004type"
-  "\030\005 \001(\0162\017.oram_impl.TypeH\000\210\001\001\022\023\n\006offset\030\006"
-  " \001(\rH\001\210\001\001B\007\n\005_typeB\t\n\007_offset\"\023\n\021WritePa"
-  "thResponse*<\n\004Type\022\017\n\013kSequential\020\000\022\013\n\007k"
-  "Random\020\001\022\t\n\005kInit\020\002\022\013\n\007kNormal\020\0032\233\t\n\013ora"
-  "m_server\022H\n\014InitTreeOram\022\036.oram_impl.Ini"
-  "tTreeOramRequest\032\026.google.protobuf.Empty"
-  "\"\000\022H\n\014InitFlatOram\022\036.oram_impl.InitFlatO"
-  "ramRequest\032\026.google.protobuf.Empty\"\000\022H\n\014"
-  "InitSqrtOram\022\036.oram_impl.InitSqrtOramReq"
-  "uest\032\026.google.protobuf.Empty\"\000\022J\n\rPrintO"
-  "ramTree\022\037.oram_impl.PrintOramTreeRequest"
-  "\032\026.google.protobuf.Empty\"\000\022E\n\010ReadPath\022\032"
-  ".oram_impl.ReadPathRequest\032\033.oram_impl.R"
-  "eadPathResponse\"\000\022H\n\tWritePath\022\033.oram_im"
-  "pl.WritePathRequest\032\034.oram_impl.WritePat"
-  "hResponse\"\000\022L\n\016ReadFlatMemory\022\032.oram_imp"
-  "l.ReadFlatRequest\032\034.oram_impl.FlatVector"
-  "Message\"\000\022I\n\017WriteFlatMemory\022\034.oram_impl"
-  ".FlatVectorMessage\032\026.google.protobuf.Emp"
-  "ty\"\000\022F\n\016ReadSqrtMemory\022\032.oram_impl.ReadS"
-  "qrtRequest\032\026.oram_impl.SqrtMessage\"\000\022H\n\017"
-  "WriteSqrtMemory\022\033.oram_impl.WriteSqrtMes"
-  "sage\032\026.google.protobuf.Empty\"\000\022C\n\013SqrtPe"
-  "rmute\022\032.oram_impl.SqrtPermMessage\032\026.goog"
-  "le.protobuf.Empty\"\000\022C\n\017CloseConnection\022\026"
-  ".google.protobuf.Empty\032\026.google.protobuf"
-  ".Empty\"\000\022N\n\013KeyExchange\022\035.oram_impl.KeyE"
-  "xchangeRequest\032\036.oram_impl.KeyExchangeRe"
-  "sponse\"\000\022>\n\tSendHello\022\027.oram_impl.HelloM"
-  "essage\032\026.google.protobuf.Empty\"\000\022K\n\027Repo"
-  "rtServerInformation\022\026.google.protobuf.Em"
-  "pty\032\026.google.protobuf.Empty\"\000\022\?\n\013ResetSe"
-  "rver\022\026.google.protobuf.Empty\032\026.google.pr"
-  "otobuf.Empty\"\000b\006proto3"
+  "size\030\004 \001(\r\"Q\n\023LoadSqrtOramRequest\022(\n\006hea"
+  "der\030\001 \001(\0132\030.oram_impl.RequestHeader\022\020\n\010c"
+  "ontents\030\002 \003(\014\"N\n\021FlatVectorMessage\022(\n\006he"
+  "ader\030\001 \001(\0132\030.oram_impl.RequestHeader\022\017\n\007"
+  "content\030\002 \001(\014\"H\n\013SqrtMessage\022(\n\006header\030\001"
+  " \001(\0132\030.oram_impl.RequestHeader\022\017\n\007conten"
+  "t\030\002 \001(\014\"r\n\020WriteSqrtMessage\022(\n\006header\030\001 "
+  "\001(\0132\030.oram_impl.RequestHeader\022\017\n\007content"
+  "\030\002 \001(\014\022\026\n\016write_to_cache\030\003 \001(\010\022\013\n\003pos\030\004 "
+  "\001(\r\"J\n\017SqrtPermMessage\022(\n\006header\030\001 \001(\0132\030"
+  ".oram_impl.RequestHeader\022\r\n\005perms\030\002 \003(\r\""
+  "|\n\023InitTreeOramRequest\022(\n\006header\030\001 \001(\0132\030"
+  ".oram_impl.RequestHeader\022\023\n\013bucket_size\030"
+  "\002 \001(\r\022\022\n\nbucket_num\030\003 \001(\r\022\022\n\nblock_size\030"
+  "\004 \001(\r\";\n\017ReadFlatRequest\022(\n\006header\030\001 \001(\013"
+  "2\030.oram_impl.RequestHeader\"[\n\017ReadSqrtRe"
+  "quest\022(\n\006header\030\001 \001(\0132\030.oram_impl.Reques"
+  "tHeader\022\013\n\003tag\030\002 \001(\r\022\021\n\tread_from\030\003 \001(\r\""
+  "X\n\017ReadPathRequest\022(\n\006header\030\001 \001(\0132\030.ora"
+  "m_impl.RequestHeader\022\014\n\004path\030\002 \001(\r\022\r\n\005le"
+  "vel\030\003 \001(\r\"\"\n\020ReadPathResponse\022\016\n\006bucket\030"
+  "\001 \003(\014\"\266\001\n\020WritePathRequest\022(\n\006header\030\001 \001"
+  "(\0132\030.oram_impl.RequestHeader\022\014\n\004path\030\002 \001"
+  "(\r\022\r\n\005level\030\003 \001(\r\022\016\n\006bucket\030\004 \003(\014\022\"\n\004typ"
+  "e\030\005 \001(\0162\017.oram_impl.TypeH\000\210\001\001\022\023\n\006offset\030"
+  "\006 \001(\rH\001\210\001\001B\007\n\005_typeB\t\n\007_offset\"\023\n\021WriteP"
+  "athResponse*<\n\004Type\022\017\n\013kSequential\020\000\022\013\n\007"
+  "kRandom\020\001\022\t\n\005kInit\020\002\022\013\n\007kNormal\020\0032\345\t\n\013or"
+  "am_server\022H\n\014InitTreeOram\022\036.oram_impl.In"
+  "itTreeOramRequest\032\026.google.protobuf.Empt"
+  "y\"\000\022H\n\014InitFlatOram\022\036.oram_impl.InitFlat"
+  "OramRequest\032\026.google.protobuf.Empty\"\000\022H\n"
+  "\014InitSqrtOram\022\036.oram_impl.InitSqrtOramRe"
+  "quest\032\026.google.protobuf.Empty\"\000\022H\n\014LoadS"
+  "qrtOram\022\036.oram_impl.LoadSqrtOramRequest\032"
+  "\026.google.protobuf.Empty\"\000\022J\n\rPrintOramTr"
+  "ee\022\037.oram_impl.PrintOramTreeRequest\032\026.go"
+  "ogle.protobuf.Empty\"\000\022E\n\010ReadPath\022\032.oram"
+  "_impl.ReadPathRequest\032\033.oram_impl.ReadPa"
+  "thResponse\"\000\022H\n\tWritePath\022\033.oram_impl.Wr"
+  "itePathRequest\032\034.oram_impl.WritePathResp"
+  "onse\"\000\022L\n\016ReadFlatMemory\022\032.oram_impl.Rea"
+  "dFlatRequest\032\034.oram_impl.FlatVectorMessa"
+  "ge\"\000\022I\n\017WriteFlatMemory\022\034.oram_impl.Flat"
+  "VectorMessage\032\026.google.protobuf.Empty\"\000\022"
+  "F\n\016ReadSqrtMemory\022\032.oram_impl.ReadSqrtRe"
+  "quest\032\026.oram_impl.SqrtMessage\"\000\022H\n\017Write"
+  "SqrtMemory\022\033.oram_impl.WriteSqrtMessage\032"
+  "\026.google.protobuf.Empty\"\000\022C\n\013SqrtPermute"
+  "\022\032.oram_impl.SqrtPermMessage\032\026.google.pr"
+  "otobuf.Empty\"\000\022C\n\017CloseConnection\022\026.goog"
+  "le.protobuf.Empty\032\026.google.protobuf.Empt"
+  "y\"\000\022N\n\013KeyExchange\022\035.oram_impl.KeyExchan"
+  "geRequest\032\036.oram_impl.KeyExchangeRespons"
+  "e\"\000\022>\n\tSendHello\022\027.oram_impl.HelloMessag"
+  "e\032\026.google.protobuf.Empty\"\000\022K\n\027ReportSer"
+  "verInformation\022\026.google.protobuf.Empty\032\026"
+  ".google.protobuf.Empty\"\000\022\?\n\013ResetServer\022"
+  "\026.google.protobuf.Empty\032\026.google.protobu"
+  "f.Empty\"\000b\006proto3"
   ;
 static const ::_pbi::DescriptorTable* const descriptor_table_messages_2eproto_deps[1] = {
   &::descriptor_table_google_2fprotobuf_2fempty_2eproto,
 };
 static ::_pbi::once_flag descriptor_table_messages_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_messages_2eproto = {
-    false, false, 2742, descriptor_table_protodef_messages_2eproto,
+    false, false, 2897, descriptor_table_protodef_messages_2eproto,
     "messages.proto",
-    &descriptor_table_messages_2eproto_once, descriptor_table_messages_2eproto_deps, 1, 18,
+    &descriptor_table_messages_2eproto_once, descriptor_table_messages_2eproto_deps, 1, 19,
     schemas, file_default_instances, TableStruct_messages_2eproto::offsets,
     file_level_metadata_messages_2eproto, file_level_enum_descriptors_messages_2eproto,
     file_level_service_descriptors_messages_2eproto,
@@ -2210,6 +2239,233 @@ void InitSqrtOramRequest::InternalSwap(InitSqrtOramRequest* other) {
 
 // ===================================================================
 
+class LoadSqrtOramRequest::_Internal {
+ public:
+  static const ::oram_impl::RequestHeader& header(const LoadSqrtOramRequest* msg);
+};
+
+const ::oram_impl::RequestHeader&
+LoadSqrtOramRequest::_Internal::header(const LoadSqrtOramRequest* msg) {
+  return *msg->_impl_.header_;
+}
+LoadSqrtOramRequest::LoadSqrtOramRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor(arena, is_message_owned);
+  // @@protoc_insertion_point(arena_constructor:oram_impl.LoadSqrtOramRequest)
+}
+LoadSqrtOramRequest::LoadSqrtOramRequest(const LoadSqrtOramRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  LoadSqrtOramRequest* const _this = this; (void)_this;
+  new (&_impl_) Impl_{
+      decltype(_impl_.contents_){from._impl_.contents_}
+    , decltype(_impl_.header_){nullptr}
+    , /*decltype(_impl_._cached_size_)*/{}};
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  if (from._internal_has_header()) {
+    _this->_impl_.header_ = new ::oram_impl::RequestHeader(*from._impl_.header_);
+  }
+  // @@protoc_insertion_point(copy_constructor:oram_impl.LoadSqrtOramRequest)
+}
+
+inline void LoadSqrtOramRequest::SharedCtor(
+    ::_pb::Arena* arena, bool is_message_owned) {
+  (void)arena;
+  (void)is_message_owned;
+  new (&_impl_) Impl_{
+      decltype(_impl_.contents_){arena}
+    , decltype(_impl_.header_){nullptr}
+    , /*decltype(_impl_._cached_size_)*/{}
+  };
+}
+
+LoadSqrtOramRequest::~LoadSqrtOramRequest() {
+  // @@protoc_insertion_point(destructor:oram_impl.LoadSqrtOramRequest)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void LoadSqrtOramRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  _impl_.contents_.~RepeatedPtrField();
+  if (this != internal_default_instance()) delete _impl_.header_;
+}
+
+void LoadSqrtOramRequest::SetCachedSize(int size) const {
+  _impl_._cached_size_.Set(size);
+}
+
+void LoadSqrtOramRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:oram_impl.LoadSqrtOramRequest)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.contents_.Clear();
+  if (GetArenaForAllocation() == nullptr && _impl_.header_ != nullptr) {
+    delete _impl_.header_;
+  }
+  _impl_.header_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* LoadSqrtOramRequest::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // .oram_impl.RequestHeader header = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_header(), ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // repeated bytes contents = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            auto str = _internal_add_contents();
+            ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<18>(ptr));
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* LoadSqrtOramRequest::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:oram_impl.LoadSqrtOramRequest)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .oram_impl.RequestHeader header = 1;
+  if (this->_internal_has_header()) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(1, _Internal::header(this),
+        _Internal::header(this).GetCachedSize(), target, stream);
+  }
+
+  // repeated bytes contents = 2;
+  for (int i = 0, n = this->_internal_contents_size(); i < n; i++) {
+    const auto& s = this->_internal_contents(i);
+    target = stream->WriteBytes(2, s, target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:oram_impl.LoadSqrtOramRequest)
+  return target;
+}
+
+size_t LoadSqrtOramRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:oram_impl.LoadSqrtOramRequest)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // repeated bytes contents = 2;
+  total_size += 1 *
+      ::PROTOBUF_NAMESPACE_ID::internal::FromIntSize(_impl_.contents_.size());
+  for (int i = 0, n = _impl_.contents_.size(); i < n; i++) {
+    total_size += ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
+      _impl_.contents_.Get(i));
+  }
+
+  // .oram_impl.RequestHeader header = 1;
+  if (this->_internal_has_header()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *_impl_.header_);
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData LoadSqrtOramRequest::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
+    LoadSqrtOramRequest::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*LoadSqrtOramRequest::GetClassData() const { return &_class_data_; }
+
+
+void LoadSqrtOramRequest::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<LoadSqrtOramRequest*>(&to_msg);
+  auto& from = static_cast<const LoadSqrtOramRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:oram_impl.LoadSqrtOramRequest)
+  GOOGLE_DCHECK_NE(&from, _this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  _this->_impl_.contents_.MergeFrom(from._impl_.contents_);
+  if (from._internal_has_header()) {
+    _this->_internal_mutable_header()->::oram_impl::RequestHeader::MergeFrom(
+        from._internal_header());
+  }
+  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void LoadSqrtOramRequest::CopyFrom(const LoadSqrtOramRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:oram_impl.LoadSqrtOramRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool LoadSqrtOramRequest::IsInitialized() const {
+  return true;
+}
+
+void LoadSqrtOramRequest::InternalSwap(LoadSqrtOramRequest* other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  _impl_.contents_.InternalSwap(&other->_impl_.contents_);
+  swap(_impl_.header_, other->_impl_.header_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata LoadSqrtOramRequest::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_messages_2eproto_getter, &descriptor_table_messages_2eproto_once,
+      file_level_metadata_messages_2eproto[7]);
+}
+
+// ===================================================================
+
 class FlatVectorMessage::_Internal {
  public:
   static const ::oram_impl::RequestHeader& header(const FlatVectorMessage* msg);
@@ -2445,7 +2701,7 @@ void FlatVectorMessage::InternalSwap(FlatVectorMessage* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata FlatVectorMessage::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_messages_2eproto_getter, &descriptor_table_messages_2eproto_once,
-      file_level_metadata_messages_2eproto[7]);
+      file_level_metadata_messages_2eproto[8]);
 }
 
 // ===================================================================
@@ -2685,7 +2941,7 @@ void SqrtMessage::InternalSwap(SqrtMessage* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata SqrtMessage::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_messages_2eproto_getter, &descriptor_table_messages_2eproto_once,
-      file_level_metadata_messages_2eproto[8]);
+      file_level_metadata_messages_2eproto[9]);
 }
 
 // ===================================================================
@@ -2984,7 +3240,7 @@ void WriteSqrtMessage::InternalSwap(WriteSqrtMessage* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata WriteSqrtMessage::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_messages_2eproto_getter, &descriptor_table_messages_2eproto_once,
-      file_level_metadata_messages_2eproto[9]);
+      file_level_metadata_messages_2eproto[10]);
 }
 
 // ===================================================================
@@ -3008,19 +3264,12 @@ SqrtPermMessage::SqrtPermMessage(const SqrtPermMessage& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   SqrtPermMessage* const _this = this; (void)_this;
   new (&_impl_) Impl_{
-      decltype(_impl_.content_){}
+      decltype(_impl_.perms_){from._impl_.perms_}
+    , /*decltype(_impl_._perms_cached_byte_size_)*/{0}
     , decltype(_impl_.header_){nullptr}
     , /*decltype(_impl_._cached_size_)*/{}};
 
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
-  _impl_.content_.InitDefault();
-  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.content_.Set("", GetArenaForAllocation());
-  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  if (!from._internal_content().empty()) {
-    _this->_impl_.content_.Set(from._internal_content(), 
-      _this->GetArenaForAllocation());
-  }
   if (from._internal_has_header()) {
     _this->_impl_.header_ = new ::oram_impl::RequestHeader(*from._impl_.header_);
   }
@@ -3032,14 +3281,11 @@ inline void SqrtPermMessage::SharedCtor(
   (void)arena;
   (void)is_message_owned;
   new (&_impl_) Impl_{
-      decltype(_impl_.content_){}
+      decltype(_impl_.perms_){arena}
+    , /*decltype(_impl_._perms_cached_byte_size_)*/{0}
     , decltype(_impl_.header_){nullptr}
     , /*decltype(_impl_._cached_size_)*/{}
   };
-  _impl_.content_.InitDefault();
-  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.content_.Set("", GetArenaForAllocation());
-  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
 }
 
 SqrtPermMessage::~SqrtPermMessage() {
@@ -3053,7 +3299,7 @@ SqrtPermMessage::~SqrtPermMessage() {
 
 inline void SqrtPermMessage::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
-  _impl_.content_.Destroy();
+  _impl_.perms_.~RepeatedField();
   if (this != internal_default_instance()) delete _impl_.header_;
 }
 
@@ -3067,7 +3313,7 @@ void SqrtPermMessage::Clear() {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  _impl_.content_.ClearToEmpty();
+  _impl_.perms_.Clear();
   if (GetArenaForAllocation() == nullptr && _impl_.header_ != nullptr) {
     delete _impl_.header_;
   }
@@ -3089,11 +3335,13 @@ const char* SqrtPermMessage::_InternalParse(const char* ptr, ::_pbi::ParseContex
         } else
           goto handle_unusual;
         continue;
-      // bytes content = 2;
+      // repeated uint32 perms = 2;
       case 2:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
-          auto str = _internal_mutable_content();
-          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::PackedUInt32Parser(_internal_mutable_perms(), ptr, ctx);
+          CHK_(ptr);
+        } else if (static_cast<uint8_t>(tag) == 16) {
+          _internal_add_perms(::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr));
           CHK_(ptr);
         } else
           goto handle_unusual;
@@ -3134,10 +3382,13 @@ uint8_t* SqrtPermMessage::_InternalSerialize(
         _Internal::header(this).GetCachedSize(), target, stream);
   }
 
-  // bytes content = 2;
-  if (!this->_internal_content().empty()) {
-    target = stream->WriteBytesMaybeAliased(
-        2, this->_internal_content(), target);
+  // repeated uint32 perms = 2;
+  {
+    int byte_size = _impl_._perms_cached_byte_size_.load(std::memory_order_relaxed);
+    if (byte_size > 0) {
+      target = stream->WriteUInt32Packed(
+          2, _internal_perms(), byte_size, target);
+    }
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -3156,11 +3407,18 @@ size_t SqrtPermMessage::ByteSizeLong() const {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  // bytes content = 2;
-  if (!this->_internal_content().empty()) {
-    total_size += 1 +
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
-        this->_internal_content());
+  // repeated uint32 perms = 2;
+  {
+    size_t data_size = ::_pbi::WireFormatLite::
+      UInt32Size(this->_impl_.perms_);
+    if (data_size > 0) {
+      total_size += 1 +
+        ::_pbi::WireFormatLite::Int32Size(static_cast<int32_t>(data_size));
+    }
+    int cached_size = ::_pbi::ToCachedSize(data_size);
+    _impl_._perms_cached_byte_size_.store(cached_size,
+                                    std::memory_order_relaxed);
+    total_size += data_size;
   }
 
   // .oram_impl.RequestHeader header = 1;
@@ -3188,9 +3446,7 @@ void SqrtPermMessage::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const 
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
 
-  if (!from._internal_content().empty()) {
-    _this->_internal_set_content(from._internal_content());
-  }
+  _this->_impl_.perms_.MergeFrom(from._impl_.perms_);
   if (from._internal_has_header()) {
     _this->_internal_mutable_header()->::oram_impl::RequestHeader::MergeFrom(
         from._internal_header());
@@ -3211,20 +3467,15 @@ bool SqrtPermMessage::IsInitialized() const {
 
 void SqrtPermMessage::InternalSwap(SqrtPermMessage* other) {
   using std::swap;
-  auto* lhs_arena = GetArenaForAllocation();
-  auto* rhs_arena = other->GetArenaForAllocation();
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
-  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
-      &_impl_.content_, lhs_arena,
-      &other->_impl_.content_, rhs_arena
-  );
+  _impl_.perms_.InternalSwap(&other->_impl_.perms_);
   swap(_impl_.header_, other->_impl_.header_);
 }
 
 ::PROTOBUF_NAMESPACE_ID::Metadata SqrtPermMessage::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_messages_2eproto_getter, &descriptor_table_messages_2eproto_once,
-      file_level_metadata_messages_2eproto[10]);
+      file_level_metadata_messages_2eproto[11]);
 }
 
 // ===================================================================
@@ -3500,7 +3751,7 @@ void InitTreeOramRequest::InternalSwap(InitTreeOramRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata InitTreeOramRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_messages_2eproto_getter, &descriptor_table_messages_2eproto_once,
-      file_level_metadata_messages_2eproto[11]);
+      file_level_metadata_messages_2eproto[12]);
 }
 
 // ===================================================================
@@ -3693,7 +3944,7 @@ void ReadFlatRequest::InternalSwap(ReadFlatRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata ReadFlatRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_messages_2eproto_getter, &descriptor_table_messages_2eproto_once,
-      file_level_metadata_messages_2eproto[12]);
+      file_level_metadata_messages_2eproto[13]);
 }
 
 // ===================================================================
@@ -3945,7 +4196,7 @@ void ReadSqrtRequest::InternalSwap(ReadSqrtRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata ReadSqrtRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_messages_2eproto_getter, &descriptor_table_messages_2eproto_once,
-      file_level_metadata_messages_2eproto[13]);
+      file_level_metadata_messages_2eproto[14]);
 }
 
 // ===================================================================
@@ -4197,7 +4448,7 @@ void ReadPathRequest::InternalSwap(ReadPathRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata ReadPathRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_messages_2eproto_getter, &descriptor_table_messages_2eproto_once,
-      file_level_metadata_messages_2eproto[14]);
+      file_level_metadata_messages_2eproto[15]);
 }
 
 // ===================================================================
@@ -4382,7 +4633,7 @@ void ReadPathResponse::InternalSwap(ReadPathResponse* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata ReadPathResponse::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_messages_2eproto_getter, &descriptor_table_messages_2eproto_once,
-      file_level_metadata_messages_2eproto[15]);
+      file_level_metadata_messages_2eproto[16]);
 }
 
 // ===================================================================
@@ -4746,7 +4997,7 @@ void WritePathRequest::InternalSwap(WritePathRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata WritePathRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_messages_2eproto_getter, &descriptor_table_messages_2eproto_once,
-      file_level_metadata_messages_2eproto[16]);
+      file_level_metadata_messages_2eproto[17]);
 }
 
 // ===================================================================
@@ -4786,7 +5037,7 @@ const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*WritePathResponse::GetClassDat
 ::PROTOBUF_NAMESPACE_ID::Metadata WritePathResponse::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_messages_2eproto_getter, &descriptor_table_messages_2eproto_once,
-      file_level_metadata_messages_2eproto[17]);
+      file_level_metadata_messages_2eproto[18]);
 }
 
 // @@protoc_insertion_point(namespace_scope)
@@ -4819,6 +5070,10 @@ Arena::CreateMaybeMessage< ::oram_impl::InitFlatOramRequest >(Arena* arena) {
 template<> PROTOBUF_NOINLINE ::oram_impl::InitSqrtOramRequest*
 Arena::CreateMaybeMessage< ::oram_impl::InitSqrtOramRequest >(Arena* arena) {
   return Arena::CreateMessageInternal< ::oram_impl::InitSqrtOramRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::oram_impl::LoadSqrtOramRequest*
+Arena::CreateMaybeMessage< ::oram_impl::LoadSqrtOramRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::oram_impl::LoadSqrtOramRequest >(arena);
 }
 template<> PROTOBUF_NOINLINE ::oram_impl::FlatVectorMessage*
 Arena::CreateMaybeMessage< ::oram_impl::FlatVectorMessage >(Arena* arena) {

--- a/protos/messages.pb.h
+++ b/protos/messages.pb.h
@@ -69,6 +69,9 @@ extern KeyExchangeRequestDefaultTypeInternal _KeyExchangeRequest_default_instanc
 class KeyExchangeResponse;
 struct KeyExchangeResponseDefaultTypeInternal;
 extern KeyExchangeResponseDefaultTypeInternal _KeyExchangeResponse_default_instance_;
+class LoadSqrtOramRequest;
+struct LoadSqrtOramRequestDefaultTypeInternal;
+extern LoadSqrtOramRequestDefaultTypeInternal _LoadSqrtOramRequest_default_instance_;
 class PrintOramTreeRequest;
 struct PrintOramTreeRequestDefaultTypeInternal;
 extern PrintOramTreeRequestDefaultTypeInternal _PrintOramTreeRequest_default_instance_;
@@ -111,6 +114,7 @@ template<> ::oram_impl::InitSqrtOramRequest* Arena::CreateMaybeMessage<::oram_im
 template<> ::oram_impl::InitTreeOramRequest* Arena::CreateMaybeMessage<::oram_impl::InitTreeOramRequest>(Arena*);
 template<> ::oram_impl::KeyExchangeRequest* Arena::CreateMaybeMessage<::oram_impl::KeyExchangeRequest>(Arena*);
 template<> ::oram_impl::KeyExchangeResponse* Arena::CreateMaybeMessage<::oram_impl::KeyExchangeResponse>(Arena*);
+template<> ::oram_impl::LoadSqrtOramRequest* Arena::CreateMaybeMessage<::oram_impl::LoadSqrtOramRequest>(Arena*);
 template<> ::oram_impl::PrintOramTreeRequest* Arena::CreateMaybeMessage<::oram_impl::PrintOramTreeRequest>(Arena*);
 template<> ::oram_impl::ReadFlatRequest* Arena::CreateMaybeMessage<::oram_impl::ReadFlatRequest>(Arena*);
 template<> ::oram_impl::ReadPathRequest* Arena::CreateMaybeMessage<::oram_impl::ReadPathRequest>(Arena*);
@@ -1326,6 +1330,189 @@ class InitSqrtOramRequest final :
 };
 // -------------------------------------------------------------------
 
+class LoadSqrtOramRequest final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:oram_impl.LoadSqrtOramRequest) */ {
+ public:
+  inline LoadSqrtOramRequest() : LoadSqrtOramRequest(nullptr) {}
+  ~LoadSqrtOramRequest() override;
+  explicit PROTOBUF_CONSTEXPR LoadSqrtOramRequest(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  LoadSqrtOramRequest(const LoadSqrtOramRequest& from);
+  LoadSqrtOramRequest(LoadSqrtOramRequest&& from) noexcept
+    : LoadSqrtOramRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline LoadSqrtOramRequest& operator=(const LoadSqrtOramRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline LoadSqrtOramRequest& operator=(LoadSqrtOramRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const LoadSqrtOramRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const LoadSqrtOramRequest* internal_default_instance() {
+    return reinterpret_cast<const LoadSqrtOramRequest*>(
+               &_LoadSqrtOramRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    7;
+
+  friend void swap(LoadSqrtOramRequest& a, LoadSqrtOramRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(LoadSqrtOramRequest* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(LoadSqrtOramRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  LoadSqrtOramRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<LoadSqrtOramRequest>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const LoadSqrtOramRequest& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom( const LoadSqrtOramRequest& from) {
+    LoadSqrtOramRequest::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(LoadSqrtOramRequest* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "oram_impl.LoadSqrtOramRequest";
+  }
+  protected:
+  explicit LoadSqrtOramRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kContentsFieldNumber = 2,
+    kHeaderFieldNumber = 1,
+  };
+  // repeated bytes contents = 2;
+  int contents_size() const;
+  private:
+  int _internal_contents_size() const;
+  public:
+  void clear_contents();
+  const std::string& contents(int index) const;
+  std::string* mutable_contents(int index);
+  void set_contents(int index, const std::string& value);
+  void set_contents(int index, std::string&& value);
+  void set_contents(int index, const char* value);
+  void set_contents(int index, const void* value, size_t size);
+  std::string* add_contents();
+  void add_contents(const std::string& value);
+  void add_contents(std::string&& value);
+  void add_contents(const char* value);
+  void add_contents(const void* value, size_t size);
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>& contents() const;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>* mutable_contents();
+  private:
+  const std::string& _internal_contents(int index) const;
+  std::string* _internal_add_contents();
+  public:
+
+  // .oram_impl.RequestHeader header = 1;
+  bool has_header() const;
+  private:
+  bool _internal_has_header() const;
+  public:
+  void clear_header();
+  const ::oram_impl::RequestHeader& header() const;
+  PROTOBUF_NODISCARD ::oram_impl::RequestHeader* release_header();
+  ::oram_impl::RequestHeader* mutable_header();
+  void set_allocated_header(::oram_impl::RequestHeader* header);
+  private:
+  const ::oram_impl::RequestHeader& _internal_header() const;
+  ::oram_impl::RequestHeader* _internal_mutable_header();
+  public:
+  void unsafe_arena_set_allocated_header(
+      ::oram_impl::RequestHeader* header);
+  ::oram_impl::RequestHeader* unsafe_arena_release_header();
+
+  // @@protoc_insertion_point(class_scope:oram_impl.LoadSqrtOramRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  struct Impl_ {
+    ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string> contents_;
+    ::oram_impl::RequestHeader* header_;
+    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_messages_2eproto;
+};
+// -------------------------------------------------------------------
+
 class FlatVectorMessage final :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:oram_impl.FlatVectorMessage) */ {
  public:
@@ -1374,7 +1561,7 @@ class FlatVectorMessage final :
                &_FlatVectorMessage_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    7;
+    8;
 
   friend void swap(FlatVectorMessage& a, FlatVectorMessage& b) {
     a.Swap(&b);
@@ -1547,7 +1734,7 @@ class SqrtMessage final :
                &_SqrtMessage_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    8;
+    9;
 
   friend void swap(SqrtMessage& a, SqrtMessage& b) {
     a.Swap(&b);
@@ -1720,7 +1907,7 @@ class WriteSqrtMessage final :
                &_WriteSqrtMessage_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    9;
+    10;
 
   friend void swap(WriteSqrtMessage& a, WriteSqrtMessage& b) {
     a.Swap(&b);
@@ -1915,7 +2102,7 @@ class SqrtPermMessage final :
                &_SqrtPermMessage_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    10;
+    11;
 
   friend void swap(SqrtPermMessage& a, SqrtPermMessage& b) {
     a.Swap(&b);
@@ -1988,22 +2175,30 @@ class SqrtPermMessage final :
   // accessors -------------------------------------------------------
 
   enum : int {
-    kContentFieldNumber = 2,
+    kPermsFieldNumber = 2,
     kHeaderFieldNumber = 1,
   };
-  // bytes content = 2;
-  void clear_content();
-  const std::string& content() const;
-  template <typename ArgT0 = const std::string&, typename... ArgT>
-  void set_content(ArgT0&& arg0, ArgT... args);
-  std::string* mutable_content();
-  PROTOBUF_NODISCARD std::string* release_content();
-  void set_allocated_content(std::string* content);
+  // repeated uint32 perms = 2;
+  int perms_size() const;
   private:
-  const std::string& _internal_content() const;
-  inline PROTOBUF_ALWAYS_INLINE void _internal_set_content(const std::string& value);
-  std::string* _internal_mutable_content();
+  int _internal_perms_size() const;
   public:
+  void clear_perms();
+  private:
+  uint32_t _internal_perms(int index) const;
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedField< uint32_t >&
+      _internal_perms() const;
+  void _internal_add_perms(uint32_t value);
+  ::PROTOBUF_NAMESPACE_ID::RepeatedField< uint32_t >*
+      _internal_mutable_perms();
+  public:
+  uint32_t perms(int index) const;
+  void set_perms(int index, uint32_t value);
+  void add_perms(uint32_t value);
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedField< uint32_t >&
+      perms() const;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedField< uint32_t >*
+      mutable_perms();
 
   // .oram_impl.RequestHeader header = 1;
   bool has_header() const;
@@ -2031,7 +2226,8 @@ class SqrtPermMessage final :
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
   struct Impl_ {
-    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr content_;
+    ::PROTOBUF_NAMESPACE_ID::RepeatedField< uint32_t > perms_;
+    mutable std::atomic<int> _perms_cached_byte_size_;
     ::oram_impl::RequestHeader* header_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   };
@@ -2088,7 +2284,7 @@ class InitTreeOramRequest final :
                &_InitTreeOramRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    11;
+    12;
 
   friend void swap(InitTreeOramRequest& a, InitTreeOramRequest& b) {
     a.Swap(&b);
@@ -2278,7 +2474,7 @@ class ReadFlatRequest final :
                &_ReadFlatRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    12;
+    13;
 
   friend void swap(ReadFlatRequest& a, ReadFlatRequest& b) {
     a.Swap(&b);
@@ -2435,7 +2631,7 @@ class ReadSqrtRequest final :
                &_ReadSqrtRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    13;
+    14;
 
   friend void swap(ReadSqrtRequest& a, ReadSqrtRequest& b) {
     a.Swap(&b);
@@ -2614,7 +2810,7 @@ class ReadPathRequest final :
                &_ReadPathRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    14;
+    15;
 
   friend void swap(ReadPathRequest& a, ReadPathRequest& b) {
     a.Swap(&b);
@@ -2793,7 +2989,7 @@ class ReadPathResponse final :
                &_ReadPathResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    15;
+    16;
 
   friend void swap(ReadPathResponse& a, ReadPathResponse& b) {
     a.Swap(&b);
@@ -2956,7 +3152,7 @@ class WritePathRequest final :
                &_WritePathRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    16;
+    17;
 
   friend void swap(WritePathRequest& a, WritePathRequest& b) {
     a.Swap(&b);
@@ -3191,7 +3387,7 @@ class WritePathResponse final :
                &_WritePathResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    17;
+    18;
 
   friend void swap(WritePathResponse& a, WritePathResponse& b) {
     a.Swap(&b);
@@ -3917,6 +4113,175 @@ inline void InitSqrtOramRequest::set_block_size(uint32_t value) {
 
 // -------------------------------------------------------------------
 
+// LoadSqrtOramRequest
+
+// .oram_impl.RequestHeader header = 1;
+inline bool LoadSqrtOramRequest::_internal_has_header() const {
+  return this != internal_default_instance() && _impl_.header_ != nullptr;
+}
+inline bool LoadSqrtOramRequest::has_header() const {
+  return _internal_has_header();
+}
+inline void LoadSqrtOramRequest::clear_header() {
+  if (GetArenaForAllocation() == nullptr && _impl_.header_ != nullptr) {
+    delete _impl_.header_;
+  }
+  _impl_.header_ = nullptr;
+}
+inline const ::oram_impl::RequestHeader& LoadSqrtOramRequest::_internal_header() const {
+  const ::oram_impl::RequestHeader* p = _impl_.header_;
+  return p != nullptr ? *p : reinterpret_cast<const ::oram_impl::RequestHeader&>(
+      ::oram_impl::_RequestHeader_default_instance_);
+}
+inline const ::oram_impl::RequestHeader& LoadSqrtOramRequest::header() const {
+  // @@protoc_insertion_point(field_get:oram_impl.LoadSqrtOramRequest.header)
+  return _internal_header();
+}
+inline void LoadSqrtOramRequest::unsafe_arena_set_allocated_header(
+    ::oram_impl::RequestHeader* header) {
+  if (GetArenaForAllocation() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(_impl_.header_);
+  }
+  _impl_.header_ = header;
+  if (header) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:oram_impl.LoadSqrtOramRequest.header)
+}
+inline ::oram_impl::RequestHeader* LoadSqrtOramRequest::release_header() {
+  
+  ::oram_impl::RequestHeader* temp = _impl_.header_;
+  _impl_.header_ = nullptr;
+#ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
+  auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
+  temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  if (GetArenaForAllocation() == nullptr) { delete old; }
+#else  // PROTOBUF_FORCE_COPY_IN_RELEASE
+  if (GetArenaForAllocation() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+#endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
+  return temp;
+}
+inline ::oram_impl::RequestHeader* LoadSqrtOramRequest::unsafe_arena_release_header() {
+  // @@protoc_insertion_point(field_release:oram_impl.LoadSqrtOramRequest.header)
+  
+  ::oram_impl::RequestHeader* temp = _impl_.header_;
+  _impl_.header_ = nullptr;
+  return temp;
+}
+inline ::oram_impl::RequestHeader* LoadSqrtOramRequest::_internal_mutable_header() {
+  
+  if (_impl_.header_ == nullptr) {
+    auto* p = CreateMaybeMessage<::oram_impl::RequestHeader>(GetArenaForAllocation());
+    _impl_.header_ = p;
+  }
+  return _impl_.header_;
+}
+inline ::oram_impl::RequestHeader* LoadSqrtOramRequest::mutable_header() {
+  ::oram_impl::RequestHeader* _msg = _internal_mutable_header();
+  // @@protoc_insertion_point(field_mutable:oram_impl.LoadSqrtOramRequest.header)
+  return _msg;
+}
+inline void LoadSqrtOramRequest::set_allocated_header(::oram_impl::RequestHeader* header) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
+  if (message_arena == nullptr) {
+    delete _impl_.header_;
+  }
+  if (header) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+        ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(header);
+    if (message_arena != submessage_arena) {
+      header = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, header, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  _impl_.header_ = header;
+  // @@protoc_insertion_point(field_set_allocated:oram_impl.LoadSqrtOramRequest.header)
+}
+
+// repeated bytes contents = 2;
+inline int LoadSqrtOramRequest::_internal_contents_size() const {
+  return _impl_.contents_.size();
+}
+inline int LoadSqrtOramRequest::contents_size() const {
+  return _internal_contents_size();
+}
+inline void LoadSqrtOramRequest::clear_contents() {
+  _impl_.contents_.Clear();
+}
+inline std::string* LoadSqrtOramRequest::add_contents() {
+  std::string* _s = _internal_add_contents();
+  // @@protoc_insertion_point(field_add_mutable:oram_impl.LoadSqrtOramRequest.contents)
+  return _s;
+}
+inline const std::string& LoadSqrtOramRequest::_internal_contents(int index) const {
+  return _impl_.contents_.Get(index);
+}
+inline const std::string& LoadSqrtOramRequest::contents(int index) const {
+  // @@protoc_insertion_point(field_get:oram_impl.LoadSqrtOramRequest.contents)
+  return _internal_contents(index);
+}
+inline std::string* LoadSqrtOramRequest::mutable_contents(int index) {
+  // @@protoc_insertion_point(field_mutable:oram_impl.LoadSqrtOramRequest.contents)
+  return _impl_.contents_.Mutable(index);
+}
+inline void LoadSqrtOramRequest::set_contents(int index, const std::string& value) {
+  _impl_.contents_.Mutable(index)->assign(value);
+  // @@protoc_insertion_point(field_set:oram_impl.LoadSqrtOramRequest.contents)
+}
+inline void LoadSqrtOramRequest::set_contents(int index, std::string&& value) {
+  _impl_.contents_.Mutable(index)->assign(std::move(value));
+  // @@protoc_insertion_point(field_set:oram_impl.LoadSqrtOramRequest.contents)
+}
+inline void LoadSqrtOramRequest::set_contents(int index, const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  _impl_.contents_.Mutable(index)->assign(value);
+  // @@protoc_insertion_point(field_set_char:oram_impl.LoadSqrtOramRequest.contents)
+}
+inline void LoadSqrtOramRequest::set_contents(int index, const void* value, size_t size) {
+  _impl_.contents_.Mutable(index)->assign(
+    reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_set_pointer:oram_impl.LoadSqrtOramRequest.contents)
+}
+inline std::string* LoadSqrtOramRequest::_internal_add_contents() {
+  return _impl_.contents_.Add();
+}
+inline void LoadSqrtOramRequest::add_contents(const std::string& value) {
+  _impl_.contents_.Add()->assign(value);
+  // @@protoc_insertion_point(field_add:oram_impl.LoadSqrtOramRequest.contents)
+}
+inline void LoadSqrtOramRequest::add_contents(std::string&& value) {
+  _impl_.contents_.Add(std::move(value));
+  // @@protoc_insertion_point(field_add:oram_impl.LoadSqrtOramRequest.contents)
+}
+inline void LoadSqrtOramRequest::add_contents(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  _impl_.contents_.Add()->assign(value);
+  // @@protoc_insertion_point(field_add_char:oram_impl.LoadSqrtOramRequest.contents)
+}
+inline void LoadSqrtOramRequest::add_contents(const void* value, size_t size) {
+  _impl_.contents_.Add()->assign(reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_add_pointer:oram_impl.LoadSqrtOramRequest.contents)
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>&
+LoadSqrtOramRequest::contents() const {
+  // @@protoc_insertion_point(field_list:oram_impl.LoadSqrtOramRequest.contents)
+  return _impl_.contents_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>*
+LoadSqrtOramRequest::mutable_contents() {
+  // @@protoc_insertion_point(field_mutable_list:oram_impl.LoadSqrtOramRequest.contents)
+  return &_impl_.contents_;
+}
+
+// -------------------------------------------------------------------
+
 // FlatVectorMessage
 
 // .oram_impl.RequestHeader header = 1;
@@ -4481,54 +4846,51 @@ inline void SqrtPermMessage::set_allocated_header(::oram_impl::RequestHeader* he
   // @@protoc_insertion_point(field_set_allocated:oram_impl.SqrtPermMessage.header)
 }
 
-// bytes content = 2;
-inline void SqrtPermMessage::clear_content() {
-  _impl_.content_.ClearToEmpty();
+// repeated uint32 perms = 2;
+inline int SqrtPermMessage::_internal_perms_size() const {
+  return _impl_.perms_.size();
 }
-inline const std::string& SqrtPermMessage::content() const {
-  // @@protoc_insertion_point(field_get:oram_impl.SqrtPermMessage.content)
-  return _internal_content();
+inline int SqrtPermMessage::perms_size() const {
+  return _internal_perms_size();
 }
-template <typename ArgT0, typename... ArgT>
-inline PROTOBUF_ALWAYS_INLINE
-void SqrtPermMessage::set_content(ArgT0&& arg0, ArgT... args) {
- 
- _impl_.content_.SetBytes(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
-  // @@protoc_insertion_point(field_set:oram_impl.SqrtPermMessage.content)
+inline void SqrtPermMessage::clear_perms() {
+  _impl_.perms_.Clear();
 }
-inline std::string* SqrtPermMessage::mutable_content() {
-  std::string* _s = _internal_mutable_content();
-  // @@protoc_insertion_point(field_mutable:oram_impl.SqrtPermMessage.content)
-  return _s;
+inline uint32_t SqrtPermMessage::_internal_perms(int index) const {
+  return _impl_.perms_.Get(index);
 }
-inline const std::string& SqrtPermMessage::_internal_content() const {
-  return _impl_.content_.Get();
+inline uint32_t SqrtPermMessage::perms(int index) const {
+  // @@protoc_insertion_point(field_get:oram_impl.SqrtPermMessage.perms)
+  return _internal_perms(index);
 }
-inline void SqrtPermMessage::_internal_set_content(const std::string& value) {
-  
-  _impl_.content_.Set(value, GetArenaForAllocation());
+inline void SqrtPermMessage::set_perms(int index, uint32_t value) {
+  _impl_.perms_.Set(index, value);
+  // @@protoc_insertion_point(field_set:oram_impl.SqrtPermMessage.perms)
 }
-inline std::string* SqrtPermMessage::_internal_mutable_content() {
-  
-  return _impl_.content_.Mutable(GetArenaForAllocation());
+inline void SqrtPermMessage::_internal_add_perms(uint32_t value) {
+  _impl_.perms_.Add(value);
 }
-inline std::string* SqrtPermMessage::release_content() {
-  // @@protoc_insertion_point(field_release:oram_impl.SqrtPermMessage.content)
-  return _impl_.content_.Release();
+inline void SqrtPermMessage::add_perms(uint32_t value) {
+  _internal_add_perms(value);
+  // @@protoc_insertion_point(field_add:oram_impl.SqrtPermMessage.perms)
 }
-inline void SqrtPermMessage::set_allocated_content(std::string* content) {
-  if (content != nullptr) {
-    
-  } else {
-    
-  }
-  _impl_.content_.SetAllocated(content, GetArenaForAllocation());
-#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  if (_impl_.content_.IsDefault()) {
-    _impl_.content_.Set("", GetArenaForAllocation());
-  }
-#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  // @@protoc_insertion_point(field_set_allocated:oram_impl.SqrtPermMessage.content)
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedField< uint32_t >&
+SqrtPermMessage::_internal_perms() const {
+  return _impl_.perms_;
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedField< uint32_t >&
+SqrtPermMessage::perms() const {
+  // @@protoc_insertion_point(field_list:oram_impl.SqrtPermMessage.perms)
+  return _internal_perms();
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedField< uint32_t >*
+SqrtPermMessage::_internal_mutable_perms() {
+  return &_impl_.perms_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedField< uint32_t >*
+SqrtPermMessage::mutable_perms() {
+  // @@protoc_insertion_point(field_mutable_list:oram_impl.SqrtPermMessage.perms)
+  return _internal_mutable_perms();
 }
 
 // -------------------------------------------------------------------
@@ -5398,6 +5760,8 @@ inline void WritePathRequest::set_offset(uint32_t value) {
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/protos/messages.proto
+++ b/protos/messages.proto
@@ -14,6 +14,8 @@ service oram_server {
 
   rpc InitSqrtOram(InitSqrtOramRequest) returns (google.protobuf.Empty) {}
 
+  rpc LoadSqrtOram(LoadSqrtOramRequest) returns (google.protobuf.Empty) {}
+
   rpc PrintOramTree(PrintOramTreeRequest) returns (google.protobuf.Empty) {}
 
   rpc ReadPath(ReadPathRequest) returns (ReadPathResponse) {}
@@ -89,6 +91,11 @@ message InitSqrtOramRequest {
   uint32 block_size = 4;
 }
 
+message LoadSqrtOramRequest {
+  RequestHeader header = 1;
+  repeated bytes contents = 2;
+}
+
 message FlatVectorMessage {
   RequestHeader header = 1;
   bytes content = 2;
@@ -109,7 +116,7 @@ message WriteSqrtMessage {
 
 message SqrtPermMessage {
   RequestHeader header = 1;
-  bytes content = 2;
+  repeated uint32 perms = 2;
 }
 
 message InitTreeOramRequest {

--- a/server/oram_server.h
+++ b/server/oram_server.h
@@ -57,6 +57,10 @@ class OramService final : public oram_server::Service {
                             const InitSqrtOramRequest* request,
                             google::protobuf::Empty* empty) override;
 
+  grpc::Status LoadSqrtOram(grpc::ServerContext* context,
+                            const LoadSqrtOramRequest* request,
+                            google::protobuf::Empty* empty) override;
+
   grpc::Status PrintOramTree(grpc::ServerContext* context,
                              const PrintOramTreeRequest* request,
                              google::protobuf::Empty* response) override;

--- a/server/sqrt_oram_storage.cc
+++ b/server/sqrt_oram_storage.cc
@@ -65,4 +65,45 @@ void SqrtOramServerStorage::DoPermute(const std::vector<uint32_t>& perm) {
   }
 }
 
+std::string SqrtOramServerStorage::ReadBlockFromShelter(uint32_t pos) {
+  const std::string ans = shelter_[pos - main_memory_.size()];
+  // Clear this position.
+  shelter_[pos - main_memory_.size()].clear();
+  return ans;
+}
+
+std::string SqrtOramServerStorage::ReadBlockFromMain(uint32_t pos) {
+  const std::string ans = main_memory_[pos];
+  main_memory_[pos].clear();
+  return ans;
+}
+
+std::string SqrtOramServerStorage::ReadBlockFromDummy(uint32_t pos) {
+  // It is meaningless to remove a block from dummy. So we keep it.
+  return dummy_[pos - main_memory_.size() - shelter_.size()];
+}
+
+void SqrtOramServerStorage::WriteBlockToShelter(const std::string& data) {
+  for (size_t i = 0; i < shelter_.size(); i++) {
+    // Find an empty space and write to it.
+    if (shelter_[i].empty()) {
+      shelter_[i] = data;
+
+      return;
+    }
+  }
+
+  // Should always find an available space for this block.
+}
+
+void SqrtOramServerStorage::Fill(const std::vector<std::string>& data) {
+  for (size_t i = 0; i < data.size(); i++) {
+    if (i < capacity_) {
+      main_memory_.emplace_back(data[i]);
+    } else {
+      shelter_.emplace_back(data[i]);
+    }
+  }
+}
+
 }  // namespace oram_impl

--- a/server/sqrt_oram_storage.h
+++ b/server/sqrt_oram_storage.h
@@ -35,19 +35,14 @@ class SqrtOramServerStorage : public BaseOramServerStorage {
         squared_m_(squared_m) {}
   bool Check(uint32_t pos, uint32_t type);
   // Position needs to "shrink to fit".
-  std::string ReadBlockFromShelter(uint32_t pos) {
-    return shelter_[pos - main_memory_.size()];
-  }
-  std::string ReadBlockFromMain(uint32_t pos) { return main_memory_[pos]; }
-  std::string ReadBlockFromDummy(uint32_t pos) {
-    return dummy_[pos - main_memory_.size() - shelter_.size()];
-  }
-  void WriteBlockToShelter(uint32_t pos, const std::string& data) {
-    shelter_[pos - main_memory_.size()] = data;
-  }
+  std::string ReadBlockFromShelter(uint32_t pos);
+  std::string ReadBlockFromMain(uint32_t pos);
+  std::string ReadBlockFromDummy(uint32_t pos);
+  void WriteBlockToShelter(const std::string& data);
   void WriteBlockToMain(uint32_t pos, const std::string& data) {
     main_memory_[pos] = data;
   }
+  void Fill(const std::vector<std::string>& data);
 
   void DoPermute(const std::vector<uint32_t>& perm);
 };

--- a/tests/oram_test_client.cc
+++ b/tests/oram_test_client.cc
@@ -40,7 +40,13 @@ int main(int argc, char* argv[]) {
   std::unique_ptr<oram_impl::OramClient> client =
       std::make_unique<oram_impl::OramClient>(config);
   client->Ready();
-  client->FillWithData();
+
+  status = client->FillWithData();
+  if (!status.ok()) {
+    logger->error("Client: FillWithData failed due to `{}`.",
+                  status.ErrorMessage());
+    abort();
+  }
 
   for (size_t i = 0; i < config.block_num; i++) {
     oram_impl::oram_block_t block;


### PR DESCRIPTION
1. Fixed some bugs in previous code:
    * Fixed a bug that will cause type mismatch.
    * Fixed a bug that accidentally overwrites the expected data.
    * Fixed a bug when reading blocks from the server.
2. Improved some implementations:
    * Improved an internal field of the Protobuf message.
    * Refined some interfaces that may cause confusion.
3. Added more implementations for `SquareRootOram`.